### PR TITLE
[Depsy] Upgrade dependency sequelize to 3.19.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "morgan": "1.6.1",
     "pg": "4.4.4",
     "pg-hstore": "2.3.2",
-    "sequelize": "3.19.0",
+    "sequelize": "3.19.1",
     "superagent": "1.7.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Hi!

A new version was just released of `sequelize`, so [Depsy](https://depsy.io)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded sequelize to 3.19.1
