### PR TITLE
[Doppins] Upgrade dependencies

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -5,7 +5,8 @@
         "indent": [2, 4],
         "new-cap": [2, {
             "capIsNewExceptions": ["Router", "ARRAY"]
-        }]
+        }],
+        "consistent-return": 0
     },
     "env": {
         "node": true,

--- a/package.json
+++ b/package.json
@@ -11,12 +11,8 @@
     "lint": "eslint --ignore-path .gitignore ."
   },
   "dependencies": {
-    "babel-cli": "6.5.1",
-    "babel-core": "6.5.2",
-    "babel-preset-es2015": "6.5.0",
-    "babel-preset-stage-0": "6.5.0",
     "bcrypt": "0.8.5",
-    "bluebird": "3.3.2",
+    "bluebird": "3.3.4",
     "body-parser": "1.15.0",
     "compression": "1.6.1",
     "continuation-local-storage": "3.1.6",
@@ -26,24 +22,28 @@
     "express": "4.13.4",
     "express-jwt": "3.3.0",
     "jsonwebtoken": "5.7.0",
-    "lodash": "4.5.1",
+    "lodash": "4.6.1",
     "method-override": "2.3.5",
     "morgan": "1.7.0",
     "pg": "4.5.1",
     "pg-hstore": "2.3.2",
     "sequelize": "3.19.3",
-    "superagent": "1.7.2"
+    "superagent": "1.8.0-beta.2"
   },
   "devDependencies": {
-    "babel-eslint": "^5.0.0-beta10",
-    "chai": "^3.4.0",
-    "chai-as-promised": "^5.1.0",
-    "eslint": "^2.2.0",
-    "eslint-config-airbnb": "^6.0.2",
-    "eslint-config-webkom": "^1.2.0",
-    "mocha": "^2.3.3",
+    "babel-cli": "^6.6.5",
+    "babel-core": "^6.6.5",
+    "babel-preset-es2015": "^6.6.0",
+    "babel-preset-stage-0": "^6.5.0",
+    "babel-eslint": "^6.0.0-beta.3",
+    "chai": "^3.5.0",
+    "chai-as-promised": "^5.2.0",
+    "eslint": "^2.3.0",
+    "eslint-config-airbnb": "^6.1.0",
+    "eslint-config-webkom": "^1.3.4",
+    "mocha": "^2.4.5",
     "sequelize-fixtures": "git+https://github.com/abakusbackup/sequelize-fixtures.git",
-    "supertest": "^1.1.0"
+    "supertest": "^1.2.0"
   },
   "private": true
 }


### PR DESCRIPTION
Hi, and thank you for trying out [Doppins](https://doppins.com).

This initial pull request upgrades all your dependency ranges to the latest
available version. From now on any new dependency releases will result in a pull
request to your repository, submitted in real-time.

Make sure that it doesn't break anything, and happy merging! :shipit:

**The upgraded dependencies are:**

---
- **babel-preset-es2015** from `6.3.13` to `6.5.0`
- **babel-preset-stage-0** from `6.3.13` to `6.5.0`
- **lodash** from `4.2.1` to `4.5.1`
- **babel-cli** from `6.4.5` to `6.5.1`
- **babel-core** from `6.4.5` to `6.5.2`
- **jsonwebtoken** from `5.5.4` to `5.7.0`
- **morgan** from `1.6.1` to `1.7.0`
- **pg** from `4.4.4` to `4.5.1`
- **body-parser** from `1.14.2` to `1.15.0`
- **sequelize** from `3.19.1` to `3.19.3`
- **bluebird** from `3.2.1` to `3.3.2`
- **eslint** from `^1.10.3` to `^2.2.0`
- **eslint-config-airbnb** from `^5.0.0` to `^6.0.2`
