### PR TITLE
[Doppins] Upgrade dependency bluebird to 3.3.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "babel-preset-es2015": "6.3.13",
     "babel-preset-stage-0": "6.3.13" ,
     "bcrypt": "0.8.5",
-    "bluebird": "3.3.3",
+    "bluebird": "3.3.4",
     "body-parser": "1.14.2",
     "compression": "1.6.1",
     "continuation-local-storage": "3.1.6",


### PR DESCRIPTION
Hi!

A new version was just released of `bluebird`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded bluebird from `3.2.1` to `3.3.3`
#### Changelog:
#### Version 3.3.3

Bugfixes:
- Fix stack overflow error when a promise returned by promisified function rejects early in a huge array when using [Promise.mapSeries](.) or [Promise.each](.)
#### Version 3.3.2

Bugfixes:
- Fix missing newline in stack trace reported by [.done()](.) ([`#1020`](.)).
- Detect deep circular resolutions
#### Version 3.3.1

Bugfixes:
- Fix crash when cancelling a [.tap()](.) handler promise ([`#1006`](.)).
#### Version 3.3.0

Features:
- Cancelling Promise returned from [Promise.delay()](.) and [.delay()](.) now calls `clearTimeout` ([`#1000`](.))
- Add [monitoring and lifecycle hooks](http://bluebirdjs.com/docs/features.html#promise-monitoring)
- Add `'warning'` hook for warnings ([`#980`](.))

Bugfixes:
- Fix warnings for "promise was rejected with non-error" being output when promises are rejected with errors from different realm ([`#990`](.))
#### Version 3.2.2

Bugfixes:
- Make build script's output work without TTY
