### PR TITLE
[Doppins] Upgrade dependency babel-eslint to ^6.0.0-beta

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "superagent": "1.7.2"
   },
   "devDependencies": {
-    "babel-eslint": "^5.0.0-beta10",
+    "babel-eslint": "^6.0.0-beta",
     "chai": "^3.4.0",
     "chai-as-promised": "^5.1.0",
     "eslint": "^1.10.3",


### PR DESCRIPTION
Hi!

A new version was just released of `babel-eslint`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded babel-eslint from `^5.0.0-beta10` to `^6.0.0-beta`
#### Changelog:
#### Version 6.0.0-beta.1
### v6.0.0-beta.1

Initial release (all current tests are passing).
- `#264` (`https://github.com/babel/babel-eslint/pull/264`)
#### Installation

`npm install babel-eslint@6.0.0-beta.1 --save-dev`

or 

``` bash
$ npm install eslint@1.x babel-eslint --save-dev
$ npm install eslint@2.x babel-eslint@next --save-dev
```

``` js
// package.json
{
  "babel-eslint": "^6.0.0-beta.1",
  "babel-eslint": "6.0.0-beta.1",
  "babel-eslint": "next",
}

```
