### PR TITLE
[Doppins] Upgrade dependency eslint to ^2.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "babel-eslint": "^5.0.0-beta10",
     "chai": "^3.4.0",
     "chai-as-promised": "^5.1.0",
-    "eslint": "^1.10.3",
+    "eslint": "^2.3.0",
     "eslint-config-airbnb": "^5.0.0",
     "eslint-config-webkom": "^1.2.0",
     "mocha": "^2.3.3",


### PR DESCRIPTION
Hi!

A new version was just released of `eslint`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded eslint from `^1.10.3` to `^2.3.0`
#### Changelog:
#### Version 2.3.0
- 1b2c6e0 Update: Proposed no-magic-numbers option: ignoreJSXNumbers (fixes `#5348`) (Brandon Beeks)
- 63c0b7d Docs: Fix incorrect environment ref. in Rules in Plugins. (fixes `#5421`) (Jesse McCarthy)
- 124c447 Build: Add additional linebreak to docs (fixes `#5464`) (Ilya Volodin)
- 0d3831b Docs: Add RuleTester parserOptions migration steps (Kevin Partington)
- 50f4d5a Fix: extends chain (fixes `#5411`) (Toru Nagashima)
- 0547072 Update: Replace getLast() with lodash.last() (fixes `#5456`) (Jordan Eldredge)
- 8c29946 Docs: Distinguish examples in rules under Possible Errors part 1 (Mark Pedrotti)
- 5319b4a Docs: Distinguish examples in rules under Possible Errors part 2 (Mark Pedrotti)
- 1da2420 Fix: crash when SourceCode object was reused (fixes `#5007`) (Toru Nagashima)
- 9e9daab New: newline-before-return rule (fixes `#5009`) (Kai Cataldo)
- e1bbe45 Fix: Check space after anonymous generator star (fixes `#5435`) (alberto)
- 119e0ed Docs: Distinguish examples in rules under Variables (Mark Pedrotti)
- 905c049 Fix: `no-undef` false positive at new.target (fixes `#5420`) (Toru Nagashima)
- 4a67b9a Update: Add ES7 support (fixes `#5401`) (Brandon Mills)
- 89c757d Docs: Replace ecmaFeatures with parserOptions in working-with-rules (Kevin Partington)
- 804c08e Docs: Add parserOptions to RuleTester section of working-with-rules (Kevin Partington)
- 1982c50 Docs: Document string option for `no-unused-vars`. (alberto)
- 4f82b2b Update: Support classes in `padded-blocks` (fixes `#5092`) (alberto)
- ed5564f Docs: Specify results of `no-unused-var` with `args` (fixes `#5334`) (chinesedfan)
- de0a4ef Fix: `getFormatter` throws an error when called as static (fixes `#5378`) (cowchimp)
- 78f7ca9 Fix: Prevent crash from swallowing console.log (fixes `#5381`) (Ian VanSchooten)
- 34b648d Fix: remove tests which have invalid syntax (fixes `#5405`) (Toru Nagashima)
- 7de5ae4 Docs: Missing allow option in  docs (Scott O'Hara)
- cf14c71 Fix: `no-useless-constructor` rule crashes sometimes (fixes `#5290`) (Burak Yigit Kaya)
- 70e3a02 Update: Allow string severity in config (fixes `#3626`) (Nicholas C. Zakas)
- 13c7c19 Update: Exclude ES5 constructors from consistent-return (fixes `#5379`) (Kevin Locke)
- 784d3bf Fix: Location info in `dot-notation` rule (fixes `#5397`) (Gyandeep Singh)
- 6280b2d Update: Support switch statements in padded-blocks (fixes `#5056`) (alberto)
- 25a5b2c Fix: Allow irregular whitespace in comments (fixes `#5368`) (Christophe Porteneuve)
- 560c0d9 New: no-restricted-globals rule implementation (fixes `#3966`) (Benoît Zugmeyer)
- c5bb478 Fix: `constructor-super` false positive after a loop (fixes `#5394`) (Toru Nagashima)
- 6c0c4aa Docs: Add Issue template (fixes `#5313`) (Kai Cataldo)
- 1170e67 Fix: indent rule doesn't handle constructor instantiation (fixes `#5384`) (Nate Cavanaugh)
- 6bc9932 Fix: Avoid magic numbers in rule options (fixes `#4182`) (Brandon Beeks)
- 694e1c1 Fix: Add tests to cover default magic number tests (fixes `#5385`) (Brandon Beeks)
- 0b5349d Fix: .eslintignore paths should be absolute (fixes `#5362`) (alberto)
- 8f6c2e7 Update: Better error message for plugins (refs `#5221`) (Nicholas C. Zakas)
- 972d41b Update: Improve error message for rule-tester (fixes `#5369`) (Jeroen Engels)
- fe3f6bd Fix: `no-self-assign` false positive at shorthand (fixes `#5371`) (Toru Nagashima)
- 2376291 Docs: Missing space in `no-fallthrough` doc. (alberto)
- 5aedb87 Docs: Add mysticatea as reviewer (Nicholas C. Zakas)
- 1f9fd10 Update: no-invalid-regexp allows custom flags (fixes `#5249`) (Afnan Fahim)
- f1eab9b Fix: Support for dash and slash in `valid-jsdoc` (fixes `#1598`) (Gyandeep Singh)
- cd12a4b Fix:`newline-per-chained-call` should only warn on methods (fixes `#5289`) (Burak Yigit Kaya)
- 0d1377d Docs: Add missing `symbol` type into valid list (Plusb Preco)
- 6aa2380 Update: prefer-const; change modified to reassigned (fixes `#5350`) (Michiel de Bruijne)
- d1d62c6 Fix: indent check for else keyword with Stroustrup style (fixes `#5218`) (Gyandeep Singh)
- 7932f78 Build: Fix commit message validation (fixes `#5340`) (Nicholas C. Zakas)
- 1c347f5 Fix: Cleanup temp files from tests (fixes `#5338`) (Nick)
- 2f3e1ae Build: Change rules to warnings in perf test (fixes `#5330`) (Brandon Mills)
- 36f40c2 Docs: Achieve consistent order of h2 in rule pages (Mark Pedrotti)
#### Version 2.2.0
- 45a22b5 Docs: remove esprima-fb from suggested parsers (Henry Zhu)
- a4d9cd3 Docs: Fix semi rule typo (Brandon Mills)
- 9d005c0 Docs: Correct option name in `no-implicit-coercion` rule (Neil Kistner)
- 2977248 Fix: Do not cache `.eslintrc.js` (fixes `#5067`) (Nick)
- 211eb8f Fix: no-multi-spaces conflicts with smart tabs (fixes `#2077`) (Afnan Fahim)
- 6dc9483 Fix: Crash in `constructor-super` (fixes `#5319`) (Burak Yigit Kaya)
- 3f48875 Docs: Fix yield star spacing examples (Dmitriy Lazarev)
- 4dab76e Docs: Update `preferType` heading to keep code format (fixes `#5307`) (chinesedfan)
- 7020b82 Fix: `sort-imports` warned between default and members (fixes `#5305`) (Toru Nagashima)
- 2f4cd1c Fix: `constructor-super` and `no-this-before-super` false (fixes `#5261`) (Toru Nagashima)
- 59e9c5b New: eslint-disable-next-line (fixes `#5206`) (Kai Cataldo)
- afb6708 Fix: `indent` rule forgot about some CallExpressions (fixes `#5295`) (Burak Yigit Kaya)
- d18d406 Docs: Update PR creation bot message (fixes `#5268`) (Nicholas C. Zakas)
- 0b1cd19 Fix: Ignore parser option if set to default parser (fixes `#5241`) (Kai Cataldo)
#### Version 2.1.0
- 7981ef5 Build: Fix release script (Nicholas C. Zakas)
- c9c34ea Fix: Skip computed members in `newline-per-chained-call` (fixes `#5245`) (Burak Yigit Kaya)
- b32ddad Build: `npm run perf` command should check the exit code (fixes `#5279`) (Burak Yigit Kaya)
- 6580d1c Docs: Fix incorrect `api.verify` JSDoc for `config` param (refs `#5104`) (Burak Yigit Kaya)
- 1f47868 Docs: Update yield-star-spacing documentation for 2.0.0 (fixes `#5272`) (Burak Yigit Kaya)
- 29da8aa Fix: `newline-after-var` crash on a switch statement (fixes `#5277`) (Toru Nagashima)
- 86c5a20 Fix: `func-style` should ignore ExportDefaultDeclarations (fixes `#5183`) (Burak Yigit Kaya)
- ba287aa Fix: Consolidate try/catches to top levels (fixes `#5243`) (Ian VanSchooten)
- 3ef5da1 Docs: Update no-magic-numbers#ignorearrayindexes. (KazuakiM)
- 0d6850e Update: Allow var declaration at end of block (fixes `#5246`) (alberto)
- c1e3a73 Fix: Popular style init handles missing package.json keys (refs `#5243`) (Brandon Mills)
- 68c6e22 Docs: fix default value of `keyword-spacing`'s overrides option. (Toru Nagashima)
- 00fe46f Upgrade: inquirer (fixes `#5265`) (Bogdan Chadkin)
- ef729d7 Docs: Remove option that is not being used in max-len rule (Thanos Lefteris)
- 4a5ddd5 Docs: Fix rule config above examples for require-jsdoc (Thanos Lefteris)
- c5cbc1b Docs: Add rule config above each example in jsx-quotes (Thanos Lefteris)
- f0aceba Docs: Correct alphabetical ordering in rule list (Randy Coulman)
- 1651ffa Docs: update migrating to 2.0.0 (fixes `#5232`) (Toru Nagashima)
- 9078537 Fix: `indent` on variable declaration with separate array (fixes `#5237`) (Burak Yigit Kaya)
- f8868b2 Docs: Typo fix in consistent-this rule doc fixes `#5240` (Nicolas Froidure)
- 44f6915 Fix: ESLint Bot mentions the wrong person for extra info (fixes `#5229`) (Burak Yigit Kaya)
- c612a8e Fix: `no-empty-function` crash (fixes `#5227`) (Toru Nagashima)
- ae663b6 Docs: Add links for issue documentation (Nicholas C. Zakas)
- 717bede Build: Switch to using eslint-release (fixes `#5223`) (Nicholas C. Zakas)
- 980e139 Fix: Combine all answers for processAnswers (fixes `#5220`) (Ian VanSchooten)
- 1f2a1d5 Docs: Remove inline errors from doc examples (fixes `#4104`) (Burak Yigit Kaya)
#### Version 2.0.0
- cc3a66b Docs: Issue message when more info is needed (Nicholas C. Zakas)
- 2bc40fa Docs: Simplify hierarchy of headings in rule pages (Mark Pedrotti)
- 1666254 Docs: Add note about only-whitespace rule for `--fix` (fixes `#4774`) (Burak Yigit Kaya)
- 2fa09d2 Docs: Add `quotes` to related section of `prefer-template` (fixes `#5192`) (Burak Yigit Kaya)
- 7b12995 Fix: `key-spacing` not enforcing no-space in minimum mode (fixes `#5008`) (Burak Yigit Kaya)
- c1c4f4d Breaking: new `no-empty-function` rule (fixes `#5161`) (Toru Nagashima)
#### Version 2.0.0
- 4dad82a Update: Adding shared environment for node and browser (refs `#5196`) (Eli White)
- b46c893 Fix: Config file relative paths (fixes `#5164`, fixes `#5160`) (Nicholas C. Zakas)
- aa5b2ac Fix: no-whitespace-before-property fixes (fixes `#5167`) (Kai Cataldo)
- 4e99924 Update: Replace several dependencies with lodash (fixes `#5012`) (Gajus Kuizinas)
- 718dc68 Docs: Remove periods in rules' README for consistency. (alberto)
- 7a47085 Docs: Correct `arrow-spacing` overview. (alberto)
- a4cde1b Docs: Clarify global-require inside try/catch (fixes `#3834`) (Brandon Mills)
- fd07925 Docs: Clarify docs for api.verify (fixes `#5101`, fixes `#5104`) (Burak Yigit Kaya)
- 413247f New: Add a --print-config flag (fixes `#5099`) (Christopher Crouzet)
- efeef42 Update: Implement auto fix for space-in-parens (fixes `#5050`) (alberto)
- e07fdd4 Fix: code path analysis and labels (fixes `#5171`) (Toru Nagashima)
- 2417bb2 Fix: `no-unmodified-loop-condition` false positive (fixes `#5166`) (Toru Nagashima)
- fae1884 Fix: Allow same-line comments in padded-blocks (fixes `#5055`) (Brandon Mills)
- a24d8ad Fix: Improve autoconfig logging (fixes `#5119`) (Ian VanSchooten)
- e525923 Docs: Correct obvious inconsistencies in rules h2 elements (Mark Pedrotti)
- 9675b5e Docs: `avoid-escape` does not allow backticks (fixes `#5147`) (alberto)
- a03919a Fix: `no-unexpected-multiline` false positive (fixes `#5148`) (Feross Aboukhadijeh)
- 74360d6 Docs: Note no-empty applies to empty block statements (fixes `#5105`) (alberto)
- 6eeaa3f Build: Remove pending tests (fixes `#5126`) (Ian VanSchooten)
- 02c83df Docs: Update docs/rules/no-plusplus.md (Sheldon Griffin)
- 0c4de5c New: Added "table" formatter (fixes `#4037`) (Gajus Kuizinas)
- 0a59926 Update: 'implied strict mode' ecmaFeature (fixes `#4832`) (Nick Evans)
- 53a6eb3 Fix: Handle singular case in rule-tester error message (fixes `#5141`) (Bryan Smith)
- 97ac91c Build: Increment eslint-config-eslint (Nicholas C. Zakas)
#### Version 2.0.0
- 973c499 Fix: `sort-imports` crash (fixes `#5130`) (Toru Nagashima)
- e64b2c2 Breaking: remove `no-empty-label` (fixes `#5042`) (Toru Nagashima)
- 79ebbc9 Breaking: update `eslint:recommended` (fixes `#5103`) (Toru Nagashima)
- e1d7368 New: `no-extra-label` rule (fixes `#5059`) (Toru Nagashima)
- c83b48c Fix: find ignore file only in cwd (fixes `#5087`) (Nicholas C. Zakas)
- 3a24240 Docs: Fix jsdoc param names to match function param names (Thanos Lefteris)
- 1d79746 Docs: Replace ecmaFeatures setting with link to config page (Thanos Lefteris)
- e96ffd2 New: `template-curly-spacing` rule (fixes `#5049`) (Toru Nagashima)
- 4b02902 Update: Extended no-console rule (fixes `#5095`) (EricHenry)
- 757651e Docs: Remove reference to rules enabled by default (fixes `#5100`) (Brandon Mills)
- 0d87f5d Docs: Clarify eslint-disable comments only affect rules (fixes `#5005`) (Brandon Mills)
- 1e791a2 New: `no-self-assign` rule (fixes `#4729`) (Toru Nagashima)
- c706eb9 Fix: reduced `no-loop-func` false positive (fixes `#5044`) (Toru Nagashima)
- 3275e86 Update: Add extra aliases to consistent-this rule (fixes `#4492`) (Zachary Alexander Belford)
- a227360 Docs: Replace joyent org with nodejs (Thanos Lefteris)
- b2aedfe New: Rule to enforce newline after each call in the chain (fixes `#4538`) (Rajendra Patil)
- d67bfdd New: `no-unused-labels` rule (fixes `#5052`) (Toru Nagashima)
#### Version 2.0.0
- 86a3e3d Update: Remove blank lines at beginning of files (fixes `#5045`) (Jared Sohn)
- 4fea752 New: Autoconfiguration from source inspection (fixes `#3567`) (Ian VanSchooten)
- 519f39f Breaking: Remove deprecated rules (fixes `#5032`) (Gyandeep Singh)
- c75ee4a New: Add support for configs in plugins (fixes `#3659`) (Ilya Volodin)
- 361377f Fix: `prefer-const` false positive reading before writing (fixes `#5074`) (Toru Nagashima)
- ff2551d Build: Improve `npm run perf` command (fixes `#5028`) (Toru Nagashima)
- bcca69b Update: add int32Hint option to `no-bitwise` rule (fixes `#4873`) (Maga D. Zandaqo)
- e3f2683 Update: config extends dependency lookup (fixes `#5023`) (Nicholas C. Zakas)
- a327a06 Fix: Indent rule for allman brace style scenario (fixes `#5064`) (Gyandeep Singh)
- afdff6d Fix: `no-extra-bind` false positive (fixes `#5058`) (Toru Nagashima)
- c1fad4f Update: add autofix support for spaced-comment (fixes `#4969`, fixes `#5030`) (Maga D. Zandaqo)
- 889b942 Revert "Docs: Update readme for legend describing rules icons (refs `#4355`)" (Nicholas C. Zakas)
- b0f21a0 Fix: `keyword-spacing` false positive in template strings (fixes `#5043`) (Toru Nagashima)
- 53fa5d1 Fix: `prefer-const` false positive in a loop condition (fixes `#5024`) (Toru Nagashima)
- 385d399 Docs: Update readme for legend describing rules icons (Kai Cataldo)
- 505f1a6 Update: Allow parser to be relative to config (fixes `#4985`) (Nicholas C. Zakas)
- 79e8a0b New: `one-var-declaration-per-line` rule (fixes `#1622`) (alberto)
- 654e6e1 Update: Check extra Boolean calls in no-extra-boolean-cast (fixes `#3650`) (Andrew Sutton)
#### Version 2.0.0
- 3fa834f Docs: Fix formatter links (fixes `#5006`) (Gyandeep Singh)
- 54b1bc8 Docs: Fix link in strict.md (fixes `#5026`) (Nick Evans)
- e0c5cf7 Upgrade: Espree to 3.0.0 (fixes `#5018`) (Ilya Volodin)
- 69f149d Docs: language tweaks (Andres Kalle)
- 2b33c74 Update: valid-jsdoc to not require `@return` in constructors (fixes `#4976`) (Maga D. Zandaqo)
- 6ac2e01 Docs: Fix description of exported comment (Mickael Jeanroy)
- 29392f8 New: allow-multiline option on comma-dangle (fixes `#4967`) (Alberto Gimeno)
- 05b8cb3 Update: Module overrides all 'strict' rule options (fixes `#4936`) (Nick Evans)
- 8470474 New: Add metadata to few test rules (fixes `#4494`) (Ilya Volodin)
- ba11c1b Docs: Add Algolia as sponsor to README (Nicholas C. Zakas)
- b28a19d Breaking: Plugins envs and config removal (fixes `#4782`, fixes `#4952`) (Nicholas C. Zakas)
- a456077 Docs: newline-after-var doesn't allow invalid options. (alberto)
- 3e6a24e Breaking: Change `strict` default mode to "safe" (fixes `#4961`) (alberto)
- 5b96265 Breaking: Update eslint:recommended (fixes `#4953`) (alberto)
- 7457a4e Upgrade: glob to 6.x (fixes `#4991`) (Gyandeep Singh)
- d3f4bdd Build: Cleanup for code coverage (fixes `#4983`) (Gyandeep Singh)
- b8fbaa0 Fix: multiple message in TAP formatter (fixes `#4975`) (Simon Degraeve)
- 990f8da Fix: `getNodeByRangeIndex` performance issue (fixes `#4989`) (Toru Nagashima)
- 8ac1dac Build: Update markdownlint dependency to 0.1.0 (fixes `#4988`) (David Anson)
- 5cd5429 Fix: function expression doc in call expression (fixes `#4964`) (Tim Schaub)
- 4173baa Fix: `no-dupe-class-members` false positive (fixes `#4981`) (Toru Nagashima)
- 12fe803 Breaking: Supports Unicode BOM (fixes `#4878`) (Toru Nagashima)
- 1fc80e9 Build: Increment eslint-config-eslint (Nicholas C. Zakas)
- e0a9024 Update: Report newline between template tag and literal (fixes `#4210`) (Rajendra Patil)
- da3336c Update: Rules should get `sourceType` from Program node (fixes `#4960`) (Nick Evans)
- a2ac359 Update: Make jsx-quotes fixable (refs `#4377`) (Gabriele Petronella)
- ee1014d Fix: Incorrect error location for object-curly-spacing (fixes `#4957`) (alberto)
- b52ed17 Fix: Incorrect error location for space-in-parens (fixes `#4956`) (alberto)
- 9c1bafb Fix: Columns of parse errors are off by 1 (fixes `#4896`) (alberto)
- 5e4841e New: 'id-blacklist' rule (fixes `#3358`) (Keith Cirkel)
- 700b8bc Update: Add "allow" option to allow specific operators (fixes `#3308`) (Rajendra Patil)
- d82eeb1 Update: Add describe around rule tester blocks (fixes `#4907`) (Ilya Volodin)
- 2967402 Update: Add minimum value to integer values in schema (fixes `#4941`) (Ilya Volodin)
- 7b632f8 Upgrade: Globals to ^8.18.0 (fixes `#4728`) (Gyandeep Singh)
- 86e6e57 Fix: Incorrect error at EOF for no-multiple-empty-lines (fixes `#4917`) (alberto)
- 7f058f3 Fix: Incorrect location for padded-blocks (fixes `#4913`) (alberto)
- b3de8f7 Fix: Do not show ignore messages for default ignored files (fixes `#4931`) (Gyandeep Singh)
- b1360da Update: Support multiLine and singleLine options (fixes `#4697`) (Rajendra Patil)
- 82fbe09 Docs: Small semantic issue in documentation example (fixes `#4937`) (Marcelo Zarate)
- 13a4e30 Docs: Formatting inconsistencies (fixes `#4912`) (alberto)
- d487013 Update: Option to allow extra parens for cond assign (fixes `#3317`) (alberto)
- 0f469b4 Fix: JSDoc for function expression on object property (fixes `#4900`) (Tim Schaub)
- c2dee27 Update: Add module tests to no-extra-semi (fixes `#4915`) (Nicholas C. Zakas)
- 5a633bf Update: Add `preferType` option to `valid-jsdoc` rule (fixes `#3056`) (Gyandeep Singh)
- ebd01b7 Build: Fix version number on release (fixes `#4921`) (Nicholas C. Zakas)
- 2d626a3 Docs: Fix typo in changelog (Nicholas C. Zakas)
- c4c4139 Fix: global-require no longer warns if require is shadowed (fixes `#4812`) (Kevin Partington)
- bbf7f27 New: provide config.parser via `parserName` on RuleContext (fixes `#3670`) (Ben Mosher)
#### Version 2.0.0
- 6c70d84 Build: Fix prerelease script (fixes `#4919`) (Nicholas C. Zakas)
- d5c9435 New: 'sort-imports' rule (refs `#3143`) (Christian Schuller)
- a8cfd56 Fix: remove duplicate of eslint-config-eslint (fixes `#4909`) (Toru Nagashima)
- 19a9fbb Breaking: `space-before-blocks` ignores after keywords (fixes `#1338`) (Toru Nagashima)
- c275b41 Fix: no-extra-parens ExpressionStatement restricted prods (fixes `#4902`) (Michael Ficarra)
- b795850 Breaking: don't load ~/.eslintrc when using --config flag (fixes `#4881`) (alberto)
- 3906481 Build: Add AppVeyor CI (fixes `#4894`) (Gyandeep Singh)
- 6390862 Docs: Fix missing footnote (Yoshiya Hinosawa)
- e5e06f8 Fix: Jsdoc comment for multi-line function expressions (fixes `#4889`) (Gyandeep Singh)
- 7c9be60 Fix: Fix path errors in windows (fixes `#4888`) (Gyandeep Singh)
- a1840e7 Fix: gray text was invisible on Solarized Dark theme (fixes `#4886`) (Jack Leigh)
- fc9f528 Docs: Modify unnecessary flag docs in quote-props (Matija Marohnić)
- 186e8f0 Update: Ignore camelcase in object destructuring (fixes `#3185`) (alberto)
- 7c97201 Upgrade: doctrine version to 1.1.0 (fixes `#4854`) (Tim Schaub)
- ceaf324 New: Add no-new-symbol rule (fixes `#4862`) (alberto)
- e2f2b66 Breaking: Remove defaults from `eslint:recommended` (fixes `#4809`) (Ian VanSchooten)
- 0b3c01e Docs: Specify default for func-style (fixes `#4834`) (Ian VanSchooten)
- 008ea39 Docs: Document default for operator assignment (fixes `#4835`) (alberto)
- b566f56 Docs: no-new-func typo (alberto)
- 1569695 Update: Adds default 'that' for consistent-this (fixes `#4833`) (alberto)
- f7b28b7 Docs: clarify `requireReturn` option for valid-jsdoc rule (fixes `#4859`) (Tim Schaub)
- 407f329 Build: Fix prerelease script (Nicholas C. Zakas)
- 688f277 Fix: Set proper exit code for Node > 0.10 (fixes `#4691`) (Nicholas C. Zakas)
- 58715e9 Fix: Use single quotes in context.report messages (fixes `#4845`) (Joe Lencioni)
- 5b7586b Fix: do not require a `@return` tag for `@interface` (fixes `#4860`) (Tim Schaub)
- d43f26c Breaking: migrate from minimatch to node-ignore (fixes `#2365`) (Stefan Grönke)
- c07ca39 Breaking: merges keyword spacing rules (fixes `#3869`) (Toru Nagashima)
- 871f534 Upgrade: Optionator version to 0.8.1 (fixes `#4851`) (Eric Johnson)
- 82d4cd9 Update: Add atomtest env (fixes `#4848`) (Andres Suarez)
- 9c9beb5 Update: Add "ignore" override for operator-linebreak (fixes `#4294`) (Rajendra Patil)
- 9c03abc Update: Add "allowCall" option (fixes `#4011`) (Rajendra Patil)
- 29516f1 Docs: fix migration guide for no-arrow-condition rule (Peter Newnham)
- 2ef7549 Docs: clarify remedy to some prefer-const errors (Turadg Aleahmad)
- 1288ba4 Update: Add default limit to `complexity` (fixes `#4808`) (Ian VanSchooten)
- d3e8179 Fix: env is rewritten by modules (fixes `#4814`) (Toru Nagashima)
- fd72aba Docs: Example fix for `no-extra-parens` rule (fixes `#3527`) (Gyandeep Singh)
- 315f272 Fix: Change max-warnings type to Int (fixes `#4660`) (George Zahariev)
- 5050768 Update: Ask for `commonjs` under config init (fixes `#3553`) (Gyandeep Singh)
- 4665256 New: Add no-whitespace-before-property rule (fixes `#1086`) (Kai Cataldo)
- f500d7d Fix: allow extending `@scope`/eslint/file (fixes `#4800`) (André Cruz)
- 5ab564e New: 'ignoreArrayIndexes' option for 'no-magic-numbers' (fixes `#4370`) (Christian Schuller)
- 97cdb95 New: Add no-useless-constructor rule (fixes `#4785`) (alberto)
- b9bcbaf Fix: Bug in no-extra-bind (fixes `#4806`) (Andres Kalle)
- 246a6d2 Docs: Documentation fix (Andres Kalle)
- 9ea6b36 Update: Ignore case in jsdoc tags (fixes `#4576`) (alberto)
- acdda24 Fix: ignore argument parens in no-unexpected-multiline (fixes `#4658`) (alberto)
- 4931f56 Update: optionally allow bitwise operators (fixes `#4742`) (Swaagie)
#### Version 2.0.0
- Build: Add prerelease script (Nicholas C. Zakas)
- Update: Allow to omit semi for one-line blocks (fixes `#4385`) (alberto)
- Fix: Handle getters and setters in key-spacing (fixes `#4792`) (Brandon Mills)
- Fix: ObjectRestSpread throws error in key-spacing rule (fixes `#4763`) (Ziad El Khoury Hanna)
- Docs: Typo in generator-star (alberto)
- Fix: Backtick behavior in quotes rule (fixes `#3090`) (Nicholas C. Zakas)
- Fix: Empty schemas forbid any options (fixes `#4789`) (Brandon Mills)
- Fix: Remove `isMarkedAsUsed` function name (fixes `#4783`) (Gyandeep Singh)
- Fix: support arrow functions in no-return-assign (fixes `#4743`) (alberto)
- Docs: Add license header to Working with Rules guide (Brandon Mills)
- Fix: RuleTester to show parsing errors (fixes `#4779`) (Nicholas C. Zakas)
- Docs: Escape underscores in no-path-concat (alberto)
- Update: configuration for classes in space-before-blocks (fixes `#4089`) (alberto)
- Docs: Typo in no-useless-concat (alberto)
- Docs: fix typos, suggests (molee1905)
- Docs: Typos in space-before-keywords and space-unary-ops (fixes `#4771`) (alberto)
- Upgrade: beefy to ^2.0.0, fixes installation errors (fixes `#4760`) (Kai Cataldo)
- Docs: Typo in no-unexpected-multiline (fixes `#4756`) (alberto)
- Update: option to ignore top-level max statements (fixes `#4309`) (alberto)
- Update: Implement auto fix for semi-spacing rule (fixes `#3829`) (alberto)
- Fix: small typos in code examples (Plusb Preco)
- Docs: Add section on file extensions to user-guide/configuring (adam)
- Fix: Comma first issue in `indent` (fixes `#4739`, fixes `#3456`) (Gyandeep Singh)
- Fix: no-constant-condition false positive (fixes `#4737`) (alberto)
- Fix: Add source property for fatal errors (fixes `#3325`) (Gyandeep Singh)
- New: Add a comment length option to the max-len rule (fixes `#4665`) (Ian)
- Docs: RuleTester doesn't require any tests (fixes `#4681`) (alberto)
- Fix: Remove path analysis from debug log (fixes `#4631`) (Ilya Volodin)
- Fix: Set null to property ruleId when fatal is true (fixes `#4722`) (Sébastien Règne)
- New: Visual Studio compatible formatter (fixes `#4708`) (rhpijnacker)
- New: Add greasemonkey environment (fixes `#4715`) (silverwind)
- Fix: always-multiline for comma-dangle import (fixes `#4704`) (Nicholas C. Zakas)
- Fix: Check 1tbs non-block else (fixes `#4692`) (Nicholas C. Zakas)
- Fix: Apply environment configs last (fixes `#3915`) (Nicholas C. Zakas)
- New: `no-unmodified-loop-condition` rule (fixes `#4523`) (Toru Nagashima)
- Breaking: deprecate `no-arrow-condition` rule (fixes `#4417`) (Luke Karrys)
- Update: Add cwd option for cli-engine (fixes `#4472`) (Ilya Volodin)
- New: Add no-confusing-arrow rule (refs `#4417`) (Luke Karrys)
- Fix: ensure `ConfigOps.merge` do a deep copy (fixes `#4682`) (Toru Nagashima)
- Fix: `no-invalid-this` allows this in static method (fixes `#4669`) (Toru Nagashima)
- Fix: Export class syntax for `require-jsdoc` rule (fixes `#4667`) (Gyandeep Singh)
- Update: Add "safe" mode to strict (fixes `#3306`) (Brandon Mills)
#### Version 2.0.0
- Breaking: Correct links between variables and references (fixes `#4615`) (Toru Nagashima)
- Fix: Update rule tests for parser options (fixes `#4673`) (Nicholas C. Zakas)
- Breaking: Implement parserOptions (fixes `#4641`) (Nicholas C. Zakas)
- Fix: max-len rule overestimates the width of some tabs (fixes `#4661`) (Nick Evans)
- New: Add no-implicit-globals rule (fixes `#4542`) (Joshua Peek)
- Update: `no-use-before-define` checks invalid initializer (fixes `#4280`) (Toru Nagashima)
- Fix: Use oneValuePerFlag for --ignore-pattern option (fixes `#4507`) (George Zahariev)
- New: `array-callback-return` rule (fixes `#1128`) (Toru Nagashima)
- Upgrade: Handlebars to >= 4.0.5 for security reasons (fixes `#4642`) (Jacques Favreau)
- Update: Add class body support to `indent` rule (fixes `#4372`) (Gyandeep Singh)
- Breaking: Remove space-after-keyword newline check (fixes `#4149`) (Nicholas C. Zakas)
- Breaking: Treat package.json like the rest of configs (fixes `#4451`) (Ilya Volodin)
- Docs: writing mistake (molee1905)
- Update: Add 'method' option to no-empty (fixes `#4605`) (Kai Cataldo)
- Breaking: Remove autofix from eqeqeq (fixes `#4578`) (Ilya Volodin)
- Breaking: Remove ES6 global variables from builtins (fixes `#4085`) (Brandon Mills)
- Fix: Handle forbidden LineTerminators in no-extra-parens (fixes `#4229`) (Brandon Mills)
- Update: Option to ignore constructor Fns object-shorthand (fixes `#4487`) (Kai Cataldo)
- Fix: Check YieldExpression argument in no-extra-parens (fixes `#4608`) (Brandon Mills)
- Fix: Do not cache `package.json` (fixes `#4611`) (Spain)
- Build: Consume no-underscore-dangle allowAfterThis option (fixes `#4599`) (Kevin Partington)
- New: Add no-restricted-imports rule (fixes `#3196`) (Guy Ellis)
- Docs: no-extra-semi no longer refers to deprecated rule (fixes `#4598`) (Kevin Partington)
- Fix: `consistent-return` checks the last (refs `#3530`, fixes `#3373`) (Toru Nagashima)
- Update: add class option to `no-use-before-define` (fixes `#3944`) (Toru Nagashima)
- Breaking: Simplify rule schemas (fixes `#3625`) (Nicholas C. Zakas)
- Docs: Update docs/rules/no-plusplus.md (Xiangyun Chi)
- Breaking: added bower_components to default ignore (fixes `#3550`) (Julian Laval)
- Fix: `no-unreachable` with the code path (refs `#3530`, fixes `#3939`) (Toru Nagashima)
- Fix: `no-this-before-super` with the code path analysis (refs `#3530`) (Toru Nagashima)
- Fix: `no-fallthrough` with the code path analysis (refs `#3530`) (Toru Nagashima)
- Fix: `constructor-super` with the code path analysis (refs `#3530`) (Toru Nagashima)
- Breaking: Switch to Espree 3.0.0 (fixes `#4334`) (Nicholas C. Zakas)
- Breaking: Freeze context object (fixes `#4495`) (Nicholas C. Zakas)
- Docs: Add Code of Conduct (fixes `#3095`) (Nicholas C. Zakas)
- Breaking: Remove warnings of readonly from `no-undef` (fixes `#4504`) (Toru Nagashima)
- Update: allowAfterThis option in no-underscore-dangle (fixes `#3435`) (just-boris)
- Fix: Adding options unit tests for --ignore-pattern (refs `#4507`) (Kevin Partington)
- Breaking: Implement yield-star-spacing rule (fixes `#4115`) (Bryan Smith)
- New: `prefer-rest-params` rule (fixes `#4108`) (Toru Nagashima)
- Update: `prefer-const` begins to cover separating init (fixes `#4474`) (Toru Nagashima)
- Fix: `no-eval` come to catch indirect eval (fixes `#4399`, fixes `#4441`) (Toru Nagashima)
- Breaking: Default no-magic-numbers to none. (fixes `#4193`) (alberto)
- Breaking: Allow empty arrow body (fixes `#4411`) (alberto)
- New: Code Path Analysis (fixes `#3530`) (Toru Nagashima)
