### PR TITLE
[Doppins] Upgrade dependency eslint to 2.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "babel-eslint": "^6.0.0-beta.3",
     "chai": "^3.5.0",
     "chai-as-promised": "^5.2.0",
-    "eslint": "2.5.3",
+    "eslint": "2.6.0",
     "eslint-config-airbnb": "^6.1.0",
     "eslint-config-webkom": "^1.3.4",
     "mocha": "^2.4.5",


### PR DESCRIPTION
Hi!

A new version was just released of `eslint`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded eslint from `2.2.0` to `2.3.0`
#### Changelog:
#### Version 2.3.0
- 1b2c6e0 Update: Proposed no-magic-numbers option: ignoreJSXNumbers (fixes `#5348`) (Brandon Beeks)
- 63c0b7d Docs: Fix incorrect environment ref. in Rules in Plugins. (fixes `#5421`) (Jesse McCarthy)
- 124c447 Build: Add additional linebreak to docs (fixes `#5464`) (Ilya Volodin)
- 0d3831b Docs: Add RuleTester parserOptions migration steps (Kevin Partington)
- 50f4d5a Fix: extends chain (fixes `#5411`) (Toru Nagashima)
- 0547072 Update: Replace getLast() with lodash.last() (fixes `#5456`) (Jordan Eldredge)
- 8c29946 Docs: Distinguish examples in rules under Possible Errors part 1 (Mark Pedrotti)
- 5319b4a Docs: Distinguish examples in rules under Possible Errors part 2 (Mark Pedrotti)
- 1da2420 Fix: crash when SourceCode object was reused (fixes `#5007`) (Toru Nagashima)
- 9e9daab New: newline-before-return rule (fixes `#5009`) (Kai Cataldo)
- e1bbe45 Fix: Check space after anonymous generator star (fixes `#5435`) (alberto)
- 119e0ed Docs: Distinguish examples in rules under Variables (Mark Pedrotti)
- 905c049 Fix: `no-undef` false positive at new.target (fixes `#5420`) (Toru Nagashima)
- 4a67b9a Update: Add ES7 support (fixes `#5401`) (Brandon Mills)
- 89c757d Docs: Replace ecmaFeatures with parserOptions in working-with-rules (Kevin Partington)
- 804c08e Docs: Add parserOptions to RuleTester section of working-with-rules (Kevin Partington)
- 1982c50 Docs: Document string option for `no-unused-vars`. (alberto)
- 4f82b2b Update: Support classes in `padded-blocks` (fixes `#5092`) (alberto)
- ed5564f Docs: Specify results of `no-unused-var` with `args` (fixes `#5334`) (chinesedfan)
- de0a4ef Fix: `getFormatter` throws an error when called as static (fixes `#5378`) (cowchimp)
- 78f7ca9 Fix: Prevent crash from swallowing console.log (fixes `#5381`) (Ian VanSchooten)
- 34b648d Fix: remove tests which have invalid syntax (fixes `#5405`) (Toru Nagashima)
- 7de5ae4 Docs: Missing allow option in  docs (Scott O'Hara)
- cf14c71 Fix: `no-useless-constructor` rule crashes sometimes (fixes `#5290`) (Burak Yigit Kaya)
- 70e3a02 Update: Allow string severity in config (fixes `#3626`) (Nicholas C. Zakas)
- 13c7c19 Update: Exclude ES5 constructors from consistent-return (fixes `#5379`) (Kevin Locke)
- 784d3bf Fix: Location info in `dot-notation` rule (fixes `#5397`) (Gyandeep Singh)
- 6280b2d Update: Support switch statements in padded-blocks (fixes `#5056`) (alberto)
- 25a5b2c Fix: Allow irregular whitespace in comments (fixes `#5368`) (Christophe Porteneuve)
- 560c0d9 New: no-restricted-globals rule implementation (fixes `#3966`) (Benoît Zugmeyer)
- c5bb478 Fix: `constructor-super` false positive after a loop (fixes `#5394`) (Toru Nagashima)
- 6c0c4aa Docs: Add Issue template (fixes `#5313`) (Kai Cataldo)
- 1170e67 Fix: indent rule doesn't handle constructor instantiation (fixes `#5384`) (Nate Cavanaugh)
- 6bc9932 Fix: Avoid magic numbers in rule options (fixes `#4182`) (Brandon Beeks)
- 694e1c1 Fix: Add tests to cover default magic number tests (fixes `#5385`) (Brandon Beeks)
- 0b5349d Fix: .eslintignore paths should be absolute (fixes `#5362`) (alberto)
- 8f6c2e7 Update: Better error message for plugins (refs `#5221`) (Nicholas C. Zakas)
- 972d41b Update: Improve error message for rule-tester (fixes `#5369`) (Jeroen Engels)
- fe3f6bd Fix: `no-self-assign` false positive at shorthand (fixes `#5371`) (Toru Nagashima)
- 2376291 Docs: Missing space in `no-fallthrough` doc. (alberto)
- 5aedb87 Docs: Add mysticatea as reviewer (Nicholas C. Zakas)
- 1f9fd10 Update: no-invalid-regexp allows custom flags (fixes `#5249`) (Afnan Fahim)
- f1eab9b Fix: Support for dash and slash in `valid-jsdoc` (fixes `#1598`) (Gyandeep Singh)
- cd12a4b Fix:`newline-per-chained-call` should only warn on methods (fixes `#5289`) (Burak Yigit Kaya)
- 0d1377d Docs: Add missing `symbol` type into valid list (Plusb Preco)
- 6aa2380 Update: prefer-const; change modified to reassigned (fixes `#5350`) (Michiel de Bruijne)
- d1d62c6 Fix: indent check for else keyword with Stroustrup style (fixes `#5218`) (Gyandeep Singh)
- 7932f78 Build: Fix commit message validation (fixes `#5340`) (Nicholas C. Zakas)
- 1c347f5 Fix: Cleanup temp files from tests (fixes `#5338`) (Nick)
- 2f3e1ae Build: Change rules to warnings in perf test (fixes `#5330`) (Brandon Mills)
- 36f40c2 Docs: Achieve consistent order of h2 in rule pages (Mark Pedrotti)
