### PR TITLE
[Doppins] Upgrade dependency superagent to 1.8.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "pg": "4.5.1",
     "pg-hstore": "2.3.2",
     "sequelize": "3.19.3",
-    "superagent": "1.8.2"
+    "superagent": "1.8.3"
   },
   "devDependencies": {
     "babel-cli": "^6.6.5",


### PR DESCRIPTION
Hi!

A new version was just released of `superagent`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded superagent from `1.8.0` to `1.8.1`
