### PR TITLE
[Doppins] Upgrade dependency sequelize to 3.20.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "morgan": "1.7.0",
     "pg": "4.5.1",
     "pg-hstore": "2.3.2",
-    "sequelize": "3.19.3",
+    "sequelize": "3.20.0",
     "superagent": "1.8.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Hi!

A new version was just released of `sequelize`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded sequelize from `3.19.3` to `3.20.0`
#### Changelog:
#### Version 3.20.0
- ADDED] rejectOnEmpty mode [`#272`](`https://github.com/sequelize/sequelize/issues/272`) [`#5480` (`https://github.com/sequelize/sequelize/issues/5480`)
- ADDED] `beforeCount` hook [`#5209` (`https://github.com/sequelize/sequelize/pull/5209`)
- ADDED] `validationFailed` hook [`#1626` (`https://github.com/sequelize/sequelize/issues/1626`)
- ADDED] Support for IEEE floating point literals in postgres and sqlite [`#5194` (`https://github.com/sequelize/sequelize/issues/5194`)
- FIXED] `addColumn` with reference in mysql [`#5592` (`https://github.com/sequelize/sequelize/issues/5592`)
- FIXED] `findAndCountAll` generates invalid SQL, subQuery moves to LEFT OUTER JOIN [`#5445` (`https://github.com/sequelize/sequelize/issues/5445`)
- FIXED] `count` methods pollute the options.includes [`#4191` (`https://github.com/sequelize/sequelize/issues/4191`)
- FIXED] Invalid SQL generated when using group option along with attributes [`#3009` (`https://github.com/sequelize/sequelize/issues/3009`)
- FIXED] Mark index as `unique: true` when `type: 'UNIQUE'`. Fixes [`#5351` (`https://github.com/sequelize/sequelize/issues/5351`)
- [FIXED] Improper escaping of bound arrays of strings on Postgres, SQLite, and Microsoft SQL Server
