### PR TITLE
[Doppins] Upgrade dependency babel-eslint to ^5.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "babel-core": "^6.6.5",
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-stage-0": "^6.5.0",
-    "babel-eslint": "^5.0.2",
+    "babel-eslint": "^5.0.4",
     "chai": "^3.5.0",
     "chai-as-promised": "^5.2.0",
     "eslint": "2.2.0",


### PR DESCRIPTION
Hi!

A new version was just released of `babel-eslint`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded babel-eslint from `^6.0.0-beta.3` to `^5.0.2`
