### PR TITLE
[Doppins] Upgrade dependency sequelize to 3.21.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "morgan": "1.7.0",
     "pg": "4.5.2",
     "pg-hstore": "2.3.2",
-    "sequelize": "3.20.0",
+    "sequelize": "3.21.0",
     "superagent": "1.8.3"
   },
   "devDependencies": {


### PR DESCRIPTION
Hi!

A new version was just released of `sequelize`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded sequelize from `3.20.0` to `3.21.0`
#### Changelog:
#### Version 3.21.0
- FIXED] Confirmed that values modified in validation hooks are preserved [`#3534` (`https://github.com/sequelize/sequelize/issues/3534`)
- FIXED] Support lower case type names in SQLite [`#5482` (`https://github.com/sequelize/sequelize/issues/5482`)
- FIXED] Support calling `setAssociation` twice on `hasOne` [`#5315` (`https://github.com/sequelize/sequelize/issues/5315`)
- [INTERNALS] Removed dependency on wellknown in favor of terraformer-wkt-parser
- ADDED] Benchmarking feature [`#2494` (`https://github.com/sequelize/sequelize/issues/2494`)
