### PR TITLE
[Doppins] Upgrade dependency eslint to 2.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "babel-eslint": "^6.0.2",
     "chai": "^3.5.0",
     "chai-as-promised": "^5.3.0",
-    "eslint": "2.6.0",
+    "eslint": "2.7.0",
     "eslint-config-airbnb": "^6.2.0",
     "eslint-config-webkom": "^1.3.4",
     "mocha": "^2.4.5",


### PR DESCRIPTION
Hi!

A new version was just released of `eslint`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded eslint from `2.6.0` to `2.7.0`
#### Changelog:
#### Version 2.7.0

134cb1f Revert "Update: adds nestedBinaryExpressions for no-extra-parens rule (fixes `#3065`)" (Ilya Volodin)
7e80867 Docs: Update sentence in fixable rules (Mark Pedrotti)
1b6d5a3 Update: adds nestedBinaryExpressions for no-extra-parens (fixes `#3065`) (Nick Fisher)
4f93c32 Docs: Clarify array-bracket-spacing with newlines (fixes `#5768`) (alberto)
161ddac Fix: remove console.dir (fixes `#5770`) (Toru Nagashima)
0c33f6a Fix: indent rule uses wrong node for class indent level (fixes `#5764`) (Paul O’Shannessy)
