### PR TITLE
[Doppins] Upgrade dependency pg to 4.5.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "lodash": "4.9.0",
     "method-override": "2.3.5",
     "morgan": "1.7.0",
-    "pg": "4.5.2",
+    "pg": "4.5.3",
     "pg-hstore": "2.3.2",
     "sequelize": "3.21.0",
     "superagent": "1.8.3"


### PR DESCRIPTION
Hi!

A new version was just released of `pg`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded pg from `4.5.2` to `4.5.3`
