### PR TITLE
[Doppins] Upgrade dependency lodash to 4.11.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "express": "4.13.4",
     "express-jwt": "3.3.0",
     "jsonwebtoken": "5.7.0",
-    "lodash": "4.11.0",
+    "lodash": "4.11.1",
     "method-override": "2.3.5",
     "morgan": "1.7.0",
     "pg": "4.5.3",


### PR DESCRIPTION
Hi!

A new version was just released of `lodash`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded lodash from `4.10.0` to `4.11.0`
