### PR TITLE
[Doppins] Upgrade dependency bluebird to 3.3.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "bcrypt": "0.8.5",
-    "bluebird": "3.3.4",
+    "bluebird": "3.3.5",
     "body-parser": "1.15.0",
     "compression": "1.6.1",
     "continuation-local-storage": "3.1.6",


### PR DESCRIPTION
Hi!

A new version was just released of `bluebird`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded bluebird from `3.3.4` to `3.3.5`
#### Changelog:
#### Version 3.3.5

Bugfixes:
- Fix then sometimes not being called on iOS/Firefox ([`#1022`](.)).
- Fix custom schedulers not being called when using promisified functions ([`#1023`](.)).
- Fix unexpected error being thrown when promisifed function is called with no arguments ([`#1063`](.)).
