### PR TITLE
[Doppins] Upgrade dependency continuation-local-storage to 3.1.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "bluebird": "3.3.5",
     "body-parser": "1.15.0",
     "compression": "1.6.1",
-    "continuation-local-storage": "3.1.6",
+    "continuation-local-storage": "3.1.7",
     "cookie-parser": "1.4.1",
     "cors": "2.7.1",
     "errorhandler": "1.4.3",


### PR DESCRIPTION
Hi!

A new version was just released of `continuation-local-storage`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded continuation-local-storage from `3.1.6` to `3.1.7`
