### PR TITLE
[Doppins] Upgrade dependency bcrypt to 0.8.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "transfer": "PG_URL=${PG_URL:-'postgres://localhost/abacash'} node scripts/transfer.js"
   },
   "dependencies": {
-    "bcrypt": "0.8.5",
+    "bcrypt": "0.8.6",
     "bluebird": "3.3.5",
     "body-parser": "1.15.0",
     "compression": "1.6.1",


### PR DESCRIPTION
Hi!

A new version was just released of `bcrypt`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded bcrypt from `0.8.5` to `0.8.6`
