### PR TITLE
[Doppins] Upgrade dependency sequelize to 3.22.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "morgan": "1.7.0",
     "pg": "4.5.3",
     "pg-hstore": "2.3.2",
-    "sequelize": "3.21.0",
+    "sequelize": "3.22.0",
     "superagent": "1.8.3"
   },
   "devDependencies": {


### PR DESCRIPTION
Hi!

A new version was just released of `sequelize`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded sequelize from `3.21.0` to `3.22.0`
