### PR TITLE
[Doppins] Upgrade dependency pg to 4.5.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "lodash": "4.11.1",
     "method-override": "2.3.5",
     "morgan": "1.7.0",
-    "pg": "4.5.4",
+    "pg": "4.5.5",
     "pg-hstore": "2.3.2",
     "sequelize": "3.22.0",
     "superagent": "1.8.3"


### PR DESCRIPTION
Hi!

A new version was just released of `pg`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded pg from `4.5.4` to `4.5.5`
