### PR TITLE
[Doppins] Upgrade dependency body-parser to 1.15.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "bcrypt": "0.8.6",
     "bluebird": "3.3.5",
-    "body-parser": "1.15.0",
+    "body-parser": "1.15.1",
     "compression": "1.6.1",
     "continuation-local-storage": "3.1.7",
     "cookie-parser": "1.4.1",


### PR DESCRIPTION
Hi!

A new version was just released of `body-parser`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded body-parser from `1.15.0` to `1.15.1`
#### Changelog:
#### Version 1.15.1
- deps: bytes@2.3.0
  - Drop partial bytes on all parsed units
  - Fix parsing byte string that looks like hex
- deps: raw-body@~2.1.6
  - deps: bytes@2.3.0
- deps: type-is@~1.6.12
  - deps: mime-types@~2.1.10
