### PR TITLE
[Doppins] Upgrade dependency sequelize to 3.23.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "pg": "4.5.5",
     "pg-hstore": "2.3.2",
     "raven": "0.10.0",
-    "sequelize": "3.22.0",
+    "sequelize": "3.23.0",
     "superagent": "1.8.3",
     "winston": "^2.2.0"
   },


### PR DESCRIPTION
Hi!

A new version was just released of `sequelize`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded sequelize from `3.22.0` to `3.23.0`
#### Changelog:
#### Version 3.23.0
- FIXED] Invalid query generated when using LIKE + ANY [`#5736` (`https://github.com/sequelize/sequelize/issues/5736`)
- FIXED] Method QueryInterface.bulkDelete no longer working when the model parameter is missing. (PostgreSQL) [`#5615` (`https://github.com/sequelize/sequelize/issues/5615`)
- [ADDED] Context and custom options for deep creation
- FIXED] Dates with millisecond precision are inserted correctly in MySQL [`#5855` (`https://github.com/sequelize/sequelize/pull/5855`)
