### PR TITLE
[Doppins] Upgrade dependency express-jwt to 3.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "cors": "2.7.1",
     "errorhandler": "1.4.3",
     "express": "4.13.4",
-    "express-jwt": "3.3.0",
+    "express-jwt": "3.4.0",
     "jsonwebtoken": "5.7.0",
     "lodash": "4.11.2",
     "method-override": "2.3.5",


### PR DESCRIPTION
Hi!

A new version was just released of `express-jwt`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded express-jwt from `3.3.0` to `3.4.0`
