### PR TITLE
[Doppins] Upgrade dependency nodemailer to 2.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "lodash": "4.11.2",
     "method-override": "2.3.5",
     "morgan": "1.7.0",
-    "nodemailer": "2.4.0",
+    "nodemailer": "2.4.1",
     "pg": "4.5.5",
     "pg-hstore": "2.3.2",
     "raven": "0.10.0",


### PR DESCRIPTION
Hi!

A new version was just released of `nodemailer`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded nodemailer from `2.3.2` to `2.4.0`
