### PR TITLE
[Doppins] Upgrade dependency raven to 0.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "nodemailer": "2.3.2",
     "pg": "4.5.5",
     "pg-hstore": "2.3.2",
-    "raven": "0.10.0",
+    "raven": "0.11.0",
     "sequelize": "3.23.0",
     "superagent": "1.8.3",
     "winston": "^2.2.0"


### PR DESCRIPTION
Hi!

A new version was just released of `raven`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded raven from `0.10.0` to `0.11.0`
