### PR TITLE
[Doppins] Upgrade dependency sequelize to 3.23.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "pg": "4.5.5",
     "pg-hstore": "2.3.2",
     "raven": "0.10.0",
-    "sequelize": "3.23.1",
+    "sequelize": "3.23.2",
     "superagent": "1.8.3",
     "winston": "^2.2.0"
   },


### PR DESCRIPTION
Hi!

A new version was just released of `sequelize`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded sequelize from `3.23.0` to `3.23.1`
#### Changelog:
#### Version 3.23.1
- FIXED] Postgres DECIMAL precision. (PostgreSQL) [`#4893` (`https://github.com/sequelize/sequelize/issues/4893`)
- FIXED] removeColumn tries to delete non-existant foreign key constraint (mysql) [`#5808` (`https://github.com/sequelize/sequelize/issues/5808`)
- FIXED] Relation constraints not being applied correctly [`#5865` (`https://github.com/sequelize/sequelize/issues/5865`)
