### PR TITLE
[Doppins] Upgrade dependency compression to 1.6.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "bcrypt": "0.8.6",
     "bluebird": "3.3.5",
     "body-parser": "1.15.1",
-    "compression": "1.6.1",
+    "compression": "1.6.2",
     "continuation-local-storage": "3.1.7",
     "cookie-parser": "1.4.1",
     "cors": "2.7.1",


### PR DESCRIPTION
Hi!

A new version was just released of `compression`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded compression from `1.6.1` to `1.6.2`
#### Changelog:
#### Version 1.6.2
- deps: accepts@~1.3.3
  - deps: mime-types@~2.1.11
  - deps: negotiator@0.6.1
- deps: bytes@2.3.0
  - Drop partial bytes on all parsed units
  - Fix parsing byte string that looks like hex
  - perf: hoist regular expressions
- deps: compressible@~2.0.8
  - deps: mime-db@'>= 1.23.0 < 2'
