### PR TITLE
[Doppins] Upgrade dependency bluebird to 3.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "bcrypt": "0.8.6",
-    "bluebird": "3.3.5",
+    "bluebird": "3.4.0",
     "body-parser": "1.15.1",
     "compression": "1.6.2",
     "continuation-local-storage": "3.1.7",


### PR DESCRIPTION
Hi!

A new version was just released of `bluebird`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded bluebird from `3.3.5` to `3.4.0`
#### Changelog:
#### Version 3.4.0

Features:
- Add `Promise.version` which tells the bluebird version as a string e.g. `"3.4.0"` ([`#1042`](.)).
- [.map](.), [Promise.map](.), [.filter](.) and [Promise.filter](.) now return rejected promise when inappropriate options argument is passed ([`#1097`](.)).

Bugfixes:
- Fix bug where callback to [.disposer](.) is not called if the resource is `null` ([`#1099`](.)).
- Fix bug where assimilating thenable throws unexpectedly when using hostile host objects as thenables ([`#1104`](.)).
