### PR TITLE
[Doppins] Upgrade dependency jsonwebtoken to 7.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "errorhandler": "1.4.3",
     "express": "4.13.4",
     "express-jwt": "3.4.0",
-    "jsonwebtoken": "6.2.0",
+    "jsonwebtoken": "7.0.0",
     "lodash": "4.12.0",
     "method-override": "2.3.5",
     "morgan": "1.7.0",


### PR DESCRIPTION
Hi!

A new version was just released of `jsonwebtoken`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded jsonwebtoken from `6.2.0` to `7.0.0`
