### PR TITLE
[Doppins] Upgrade dependency method-override to 2.3.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "express-jwt": "3.4.0",
     "jsonwebtoken": "7.0.0",
     "lodash": "4.12.0",
-    "method-override": "2.3.5",
+    "method-override": "2.3.6",
     "morgan": "1.7.0",
     "nodemailer": "2.4.1",
     "pg": "4.5.5",


### PR DESCRIPTION
Hi!

A new version was just released of `method-override`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded method-override from `2.3.5` to `2.3.6`
#### Changelog:
#### Version 2.3.6
- deps: methods@~1.1.2
  - perf: enable strict mode
- deps: parseurl@~1.3.1
  - perf: enable strict mode
- deps: vary@~1.1.0
