### PR TITLE
[Doppins] Upgrade dependency lodash to 4.13.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "express": "4.13.4",
     "express-jwt": "3.4.0",
     "jsonwebtoken": "7.0.0",
-    "lodash": "4.12.0",
+    "lodash": "4.13.0",
     "method-override": "2.3.6",
     "morgan": "1.7.0",
     "nodemailer": "2.4.1",


### PR DESCRIPTION
Hi!

A new version was just released of `lodash`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded lodash from `4.12.0` to `4.13.0`
