### PR TITLE
[Doppins] Upgrade dependency sequelize to 3.23.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "nodemailer": "2.4.2",
     "pg": "4.5.5",
     "pg-hstore": "2.3.2",
-    "sequelize": "3.23.2",
+    "sequelize": "3.23.3",
     "raven": "0.11.0",
     "superagent": "1.8.3",
     "winston": "^2.2.0"


### PR DESCRIPTION
Hi!

A new version was just released of `sequelize`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded sequelize from `3.23.2` to `3.23.3`
#### Changelog:
#### Version 3.23.3
- [FIXED] Pass ResourceLock instead of raw connection in MSSQL disconnect handling
