### PR TITLE
[Doppins] Upgrade dependency cookie-parser to 1.4.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "body-parser": "1.15.1",
     "compression": "1.6.2",
     "continuation-local-storage": "3.1.7",
-    "cookie-parser": "1.4.2",
+    "cookie-parser": "1.4.3",
     "cors": "2.7.1",
     "errorhandler": "1.4.3",
     "express": "4.13.4",


### PR DESCRIPTION
Hi!

A new version was just released of `cookie-parser`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded cookie-parser from `1.4.2` to `1.4.3`
#### Changelog:
#### Version 1.4.3
- deps: cookie@0.3.1
  - perf: use for loop in parse
