### PR TITLE
[Doppins] Upgrade dependency superagent to 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "pg-hstore": "2.3.2",
     "sequelize": "3.23.3",
     "raven": "0.11.0",
-    "superagent": "1.8.3",
+    "superagent": "2.0.0",
     "winston": "^2.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Hi!

A new version was just released of `superagent`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded superagent from `1.8.3` to `2.0.0`
#### Changelog:
#### Version 2.0.0

To try alpha versions:

```
npm install superagent@next
```
## Breaking changes

Breaking changes are in rarely used functionality, so we hope upgrade will be smooth for most users.
- Browser: The `.parse()` method has been renamed to `.serialize()` to avoid inconsistency with NodeJS version (v1.8.3 supports `.serialize()` too)
- Browser: Query string keys without a value used to be parsed as `'undefined'`, now their value is `''` (empty string) (shura, Kornel Lesiński).
- NodeJS: The `redirect` event is called after new query string and headers have been set and is allowed to override the request URL (Kornel Lesiński)
- `.then()` returns a real `Promise`. Note that use of superagent with promises now requires a global `Promise` object.
  If you target Internet Explorer or Node 0.10, you'll need `require('es6-promise').polyfill()` or similar.
- Upgraded all dependencies (Peter Lyons)
- Renamed properties documented as ``@api` private`to have`_prefixed` names (Kornel Lesiński)
## Probably not breaking changes:
- Extracted common functions to request-base (Peter Lyons)
- Fixed race condition in pipe tests (Peter Lyons)
- Handle `FormData` error events (scriptype)
- Fixed wrong jsdoc of Request#attach (George Chung)
- Updated and improved tests (Peter Lyons)
