### PR TITLE
[Doppins] Upgrade dependency eslint to 2.11.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "chai": "^3.5.0",
     "chai-as-promised": "^5.3.0",
     "commander": "^2.9.0",
-    "eslint": "2.11.0",
+    "eslint": "2.11.1",
     "eslint-config-airbnb": "^9.0.0",
     "eslint-config-webkom": "^1.3.4",
     "eslint-plugin-import": "^1.6.1",


### PR DESCRIPTION
Hi!

A new version was just released of `eslint`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded eslint from `2.11.0` to `2.11.1`
#### Changelog:
#### Version 2.11.1
- 64b0d0c Fix: failed to parse `/*eslint` comments by colon (fixes `#6224`) (`#6258`) (Toru Nagashima)
- c8936eb Build: Don't check commit count (fixes `#5935`) (`#6263`) (Nicholas C. Zakas)
- 113c1a8 Fix: `max-statements-per-line` false positive at exports (fixes `#6264`) (`#6268`) (Toru Nagashima)
- 03beb27 Fix: `no-useless-rename` false positives (fixes `#6266`) (`#6267`) (alberto)
- fe89037 Docs: Fix rule name in example (`#6279`) (Kenneth Williams)
