### PR TITLE
[Doppins] Upgrade dependency bcrypt to 0.8.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "transfer": "PG_URL=${PG_URL:-'postgres://localhost/abacash'} node scripts/transfer.js"
   },
   "dependencies": {
-    "bcrypt": "0.8.6",
+    "bcrypt": "0.8.7",
     "bluebird": "3.4.0",
     "body-parser": "1.15.1",
     "compression": "1.6.2",


### PR DESCRIPTION
Hi!

A new version was just released of `bcrypt`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded bcrypt from `0.8.6` to `0.8.7`
