### PR TITLE
[Doppins] Upgrade dependency eslint to 2.13.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "chai": "^3.5.0",
     "chai-as-promised": "^5.3.0",
     "commander": "^2.9.0",
-    "eslint": "2.13.0",
+    "eslint": "2.13.1",
     "eslint-config-airbnb": "^9.0.0",
     "eslint-config-webkom": "^1.3.4",
     "eslint-plugin-import": "^1.6.1",


### PR DESCRIPTION
Hi!

A new version was just released of `eslint`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded eslint from `2.11.1` to `2.12.0`
