### PR TITLE
[Doppins] Upgrade dependency express to 4.14.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "cookie-parser": "1.4.3",
     "cors": "2.7.1",
     "errorhandler": "1.4.3",
-    "express": "4.13.4",
+    "express": "4.14.0",
     "express-handlebars": "^3.0.0",
     "express-jwt": "3.4.0",
     "jsonwebtoken": "7.0.0",


### PR DESCRIPTION
Hi!

A new version was just released of `express`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded express from `4.13.4` to `4.14.0`
#### Changelog:
#### Version 5.0.0-alpha.2

This is the second Express 5.0 alpha release, based off 4.13.1 and includes
changes from 5.0.0-alpha.1.
- remove:
  - `app.param(fn)`
  - `req.param()` -- use `req.params`, `req.body`, or `req.query` instead
- change:
  - `res.render` callback is always async, even for sync view engines
  - The leading `:` character in `name` for `app.param(name, fn)` is no longer removed
  - Use `router` module for routing
  - Use `path-is-absolute` module for absolute path detection
#### Version 5.0.0-alpha.1
- remove:
  - `app.del` - use `app.delete`
  - `req.acceptsCharset` - use `req.acceptsCharsets`
  - `req.acceptsEncoding` - use `req.acceptsEncodings`
  - `req.acceptsLanguage` - use `req.acceptsLanguages`
  - `res.json(obj, status)` signature - use `res.json(status, obj)`
  - `res.jsonp(obj, status)` signature - use `res.jsonp(status, obj)`
  - `res.send(body, status)` signature - use `res.send(status, body)`
  - `res.send(status)` signature - use `res.sendStatus(status)`
  - `res.sendfile` - use `res.sendFile` instead
  - `express.query` middleware
- change:
  - `req.host` now returns host (`hostname:port`) - use `req.hostname` for only hostname
  - `req.query` is now a getter instead of a plain property
- add:
  - `app.router` is a reference to the base router
