### PR TITLE
[Doppins] Upgrade dependency bluebird to 3.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "bcrypt": "0.8.6",
-    "bluebird": "3.4.0",
+    "bluebird": "3.4.1",
     "body-parser": "1.15.1",
     "compression": "1.6.2",
     "continuation-local-storage": "3.1.7",


### PR DESCRIPTION
Hi!

A new version was just released of `bluebird`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded bluebird from `3.4.0` to `3.4.1`
#### Changelog:
#### Version 3.4.1

Features:
- Added [Promise.getNewLibraryCopy](.)
