### PR TITLE
[Doppins] Upgrade dependency body-parser to 1.15.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "bcrypt": "0.8.6",
     "bluebird": "3.4.0",
-    "body-parser": "1.15.1",
+    "body-parser": "1.15.2",
     "compression": "1.6.2",
     "continuation-local-storage": "3.1.7",
     "cookie-parser": "1.4.3",


### PR DESCRIPTION
Hi!

A new version was just released of `body-parser`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded body-parser from `1.15.1` to `1.15.2`
#### Changelog:
#### Version 1.15.2
- deps: bytes@2.4.0
- deps: content-type@~1.0.2
  - perf: enable strict mode
- deps: http-errors@~1.5.0
  - Use `setprototypeof` module to replace `__proto__` setting
  - deps: statuses@'>= 1.3.0 < 2'
  - perf: enable strict mode
- deps: qs@6.2.0
- deps: raw-body@~2.1.7
  - deps: bytes@2.4.0
  - perf: remove double-cleanup on happy path
- deps: type-is@~1.6.13
  - deps: mime-types@~2.1.11
