### PR TITLE
[Doppins] Upgrade dependency bluebird to 3.4.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "bcrypt": "0.8.6",
-    "bluebird": "3.4.0",
+    "bluebird": "3.4.6",
     "body-parser": "1.15.1",
     "compression": "1.6.2",
     "continuation-local-storage": "3.1.7",


### PR DESCRIPTION
Hi!

A new version was just released of `bluebird`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded bluebird from `3.4.0` to `3.4.6`

#### Changelog:

#### Version 3.4.6
Bugfixes:

- Fix [Promise.map](.) and [.map](.) not always calling the callback asynchronously \([`#1148`](.)\)

#### Version 3.4.5
Bugfixes:

 - Fix unhandled error regression introduced in 3.4.3 [`#1217`](.)

#### Version 3.4.4
Bugfixes:

 - Fix benchmark parallel in node 6 [`#1165`](.)
 - Fix memory leak with Promise.each [`#1057`](.)
 - Fix thenable passed to .return being evaluated too early [`#1210`](.)
 - Fix "unhandledrejection" event not having .detail field when using DOM3 event listener api [`#1209`](.)
 - Fix [Promise.join](.) not ensuring asynchronous callback [`#1153`](.)
 - Fix domains leaking when synchronous error is thrown while a domain is active [`#1125`](.)

#### Version 3.4.3
Bugfixes:

 - The "a promise was created in a handler but not returned from it" warning now highlights the file, line and column where the return statement is missing.
 - The "a promise was created in a handler but not returned from it" warning now adds the bluebird API method used to create the non-returned promise at the top of the warning stack

#### Version 3.4.2
Bugfixes:

 - Add missing link to unhandled warning docs \([`#1205`](.)\)
 - Fix [Promise.delay](.) not having a long stack trace \([`#1182`](.)\)
 - Fix false unhandled rejection when a rejected promise originating from one copy of bluebird is passed to another copy's [.return](.) or [.catchReturn](.) \([`#1186`](.)\)
 - Fix Promise.resolve is not a function error \([`#1192`](.)\)
 - Fix global events not being fired through DOM 3 API inside a worker \([`#1190`](.)\)
 - Fix .cancel() not immediately marking a promise as being cancelled if it has cancellable parent \([`#1187`](.)\)
 - Fix maximum callstack exceeded with [Promise.coroutine](.) \([`#1170`](.)\)

#### Version 3.4.1
Features:

 - Added [Promise.getNewLibraryCopy](.)

