### PR TITLE
[Doppins] Upgrade dependency cors to 2.8.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "compression": "1.6.2",
     "continuation-local-storage": "3.1.7",
     "cookie-parser": "1.4.3",
-    "cors": "2.7.1",
+    "cors": "2.8.1",
     "errorhandler": "1.4.3",
     "express": "4.13.4",
     "express-handlebars": "^3.0.0",


### PR DESCRIPTION
Hi!

A new version was just released of `cors`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded cors from `2.7.1` to `2.8.1`

