### PR TITLE
[Doppins] Upgrade dependency jsonwebtoken to 7.1.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "express": "4.13.4",
     "express-handlebars": "^3.0.0",
     "express-jwt": "3.4.0",
-    "jsonwebtoken": "7.0.0",
+    "jsonwebtoken": "7.1.9",
     "lodash": "4.13.1",
     "method-override": "2.3.6",
     "morgan": "1.7.0",


### PR DESCRIPTION
Hi!

A new version was just released of `jsonwebtoken`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded jsonwebtoken from `7.0.0` to `7.1.9`

