### PR TITLE
[Doppins] Upgrade dependency continuation-local-storage to 3.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "bluebird": "3.4.0",
     "body-parser": "1.15.1",
     "compression": "1.6.2",
-    "continuation-local-storage": "3.1.7",
+    "continuation-local-storage": "3.2.0",
     "cookie-parser": "1.4.3",
     "cors": "2.7.1",
     "errorhandler": "1.4.3",


### PR DESCRIPTION
Hi!

A new version was just released of `continuation-local-storage`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded continuation-local-storage from `3.1.7` to `3.2.0`

