### PR TITLE
[Doppins] Upgrade dependency nodemailer to 2.6.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "lodash": "4.13.1",
     "method-override": "2.3.6",
     "morgan": "1.7.0",
-    "nodemailer": "2.4.2",
+    "nodemailer": "2.6.4",
     "nodemailer-express-handlebars": "^2.0.0",
     "pg": "6.0.0",
     "pg-hstore": "2.3.2",


### PR DESCRIPTION
Hi!

A new version was just released of `nodemailer`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded nodemailer from `2.4.2` to `2.6.4`

