### PR TITLE
[Doppins] Upgrade dependency raven to 0.12.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "nodemailer-express-handlebars": "^2.0.0",
     "pg": "6.0.0",
     "pg-hstore": "2.3.2",
-    "raven": "0.11.0",
+    "raven": "0.12.1",
     "sequelize": "3.23.3",
     "superagent": "2.0.0",
     "winston": "^2.2.0"


### PR DESCRIPTION
Hi!

A new version was just released of `raven`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded raven from `0.11.0` to `0.12.1`

#### Changelog:

#### Version 0.12.0
* Add `environment` config option and `setRelease` method [See `#179`]
* No longer passes `process.env` values [See `#182`]
* Connect/Express middleware now attempts to attach `req.user` as User interface [See `#177`]
* Use json-stringify-safe to prevent circular refs [See `#182`]


