### PR TITLE
[Doppins] Upgrade dependency pg to 6.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "morgan": "1.7.0",
     "nodemailer": "2.4.2",
     "nodemailer-express-handlebars": "^2.0.0",
-    "pg": "6.0.0",
+    "pg": "6.1.0",
     "pg-hstore": "2.3.2",
     "raven": "0.11.0",
     "sequelize": "3.23.3",


### PR DESCRIPTION
Hi!

A new version was just released of `pg`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded pg from `6.0.0` to `6.1.0`

