### PR TITLE
[Doppins] Upgrade dependency express-jwt to 5.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "errorhandler": "1.4.3",
     "express": "4.13.4",
     "express-handlebars": "^3.0.0",
-    "express-jwt": "3.4.0",
+    "express-jwt": "5.1.0",
     "jsonwebtoken": "7.0.0",
     "lodash": "4.13.1",
     "method-override": "2.3.6",


### PR DESCRIPTION
Hi!

A new version was just released of `express-jwt`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded express-jwt from `3.4.0` to `5.1.0`

