### PR TITLE
[Doppins] Upgrade dependency sequelize to 3.25.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "pg": "6.0.0",
     "pg-hstore": "2.3.2",
     "raven": "0.11.0",
-    "sequelize": "3.23.3",
+    "sequelize": "3.25.0",
     "superagent": "2.0.0",
     "winston": "^2.2.0"
   },


### PR DESCRIPTION
Hi!

A new version was just released of `sequelize`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded sequelize from `3.23.3` to `3.25.0`

#### Changelog:

#### Version 3.25.0
- [FIXED] Set `timestamps` and `paranoid` options from through model on `belongsToMany` association
- [FIXED] Properly apply paranoid condition when `groupedLimit.on` association is `paranoid`
- [FIXED] `restore` now uses `field` from `deletedAt`
- ADDED] `option.silent` for increment and decrement [`#6793` (`https://github.com/sequelize/sequelize/pull/6793`)

#### Version 3.24.8
[FIXED] restore now uses field from deletedAt

#### Version 3.24.7
[FIXED] MSSQL bulkInsertQuery when options and attributes are not passed [`#6782`]


#### Version 3.24.2
- FIXED] Accept dates as string while using `typeValidation` [`#6453` (`https://github.com/sequelize/sequelize/issues/6453`)


#### Version 3.24.3
- [ADDED] Backport of grouped limit include support 
- ADDED] Export datatypes [`#6578` (`https://github.com/sequelize/sequelize/pull/6578`)

#### Version 3.24.4
- [FIXED] - ORDER clause was not included in subquery if `order` option value was provided as plain string (not as an array value)
- FIXED] Issue with belongsTo association and foreign keys [`#6400` (`https://github.com/sequelize/sequelize/issues/6400`)
- FIXED] Check that parent exists before appending attributes [`#6472` (`https://github.com/sequelize/sequelize/issues/6472`)
- FIXED] Default options for insert queries [`#6644` (`https://github.com/sequelize/sequelize/pull/6644`)

#### Version 4.0.0-2
- [ADDED] include now supports string as an argument (on top of model/association), string will expand into an association matched literally from Model.associations
- FIXED] Accept dates as string while using `typeValidation` [`#6453` (`https://github.com/sequelize/sequelize/issues/6453`)
- [FIXED] - ORDER clause was not included in subquery if `order` option value was provided as plain string (not as an array value)
- [FIXED] support for CLS with `cls-bluebird` module

#### Version 4.0.0-1
- CHANGED] Removed `modelManager` parameter from `Model.init()` [`#6437` (`https://github.com/sequelize/sequelize/issues/6437`)
- FIXED] Made `Model.init()` behave like `sequelize.define()` (hooks are called and options have proper defaults) [`#6437` (`https://github.com/sequelize/sequelize/issues/6437`)
- ADDED] `restartIdentity` option for truncate in postgres [`#5356` (`https://github.com/sequelize/sequelize/issues/5356`)
- INTERNAL] Migrated to `node-mysql2` for prepared statements [`#6354` (`https://github.com/sequelize/sequelize/issues/6354`)
- [ADDED] SQLCipher support via the SQLite connection manager
- CHANGED] Range type bounds now default to [postgres default](https://www.postgresql.org/docs/9.5/static/rangetypes.html#RANGETYPES-CONSTRUCT) `[)` (inclusive, exclusive) [`#5990` (`https://github.com/sequelize/sequelize/issues/5990`)
- ADDED] Support for range operators [`#5990` (`https://github.com/sequelize/sequelize/issues/5990`)
- FIXED] Broken transactions in `MySQL` [`#3568` (`https://github.com/sequelize/sequelize/issues/3568`)
- FIXED] `Model.count` don't include attributes [`#5057` (`https://github.com/sequelize/sequelize/issues/5057`)
- [INTERNALS] Updated `inflection` dependency and pinned version and expose all used `inflection` methods on `Utils`
- [ADDED] `Sequelize.useInflection` method
- FIXED] `hasOne` throws error on update with a primary key [`#6069` (`https://github.com/sequelize/sequelize/issues/6069`)
- FIXED] `Model.count` gives SQL syntax error when using `distinct` [`#4840` (`https://github.com/sequelize/sequelize/issues/4840`)
- ADDED] `Model.count` now allow specifying column to count on, use `options.col` [`#4442` (`https://github.com/sequelize/sequelize/issues/4442`)
- ADDED] `DEBUG` support [`#2852` (`https://github.com/sequelize/sequelize/issues/2852`)
- ADDED] Intensive connection logging [`#851` (`https://github.com/sequelize/sequelize/issues/851`)
- FIXED] Only `belongsTo` uses `as` to construct foreign key - revert of [`#5957` (`https://github.com/sequelize/sequelize/pull/5957`) introduced in 4.0.0-0
- CHANGED] `Sequelize.Promise` is now an independent copy of `bluebird` library [`#5974` (`https://github.com/sequelize/sequelize/issues/5974`)
- ADDED] before/after Save hook [`#2702` (`https://github.com/sequelize/sequelize/issues/2702`)
- ADDED] Remove hooks by reference [`#6155` (`https://github.com/sequelize/sequelize/issues/6155`)
- ADDED] before/after Upsert hook [`#3965` (`https://github.com/sequelize/sequelize/issues/3965`)
- FIXED] Modifying `options` in `beforeFind` throws error [`#5675` (`https://github.com/sequelize/sequelize/issues/5675`)
- REMOVED] `classMethods` and `instanceMethods` [`#5869` (`https://github.com/sequelize/sequelize/issues/5869#issuecomment-221773485`)
- [CHANGED] `Sequelize.Validator` is now an independent copy of `validator` library
- FIXED] Don't patch `validator` library globally [`#6196` (`https://github.com/sequelize/sequelize/issues/6196`)
- CHANGED] `ignore` for create was renamed to `ignoreDuplicates` [`#6138` (`https://github.com/sequelize/sequelize/issues/6138`)
- FIXED] Index names not quoted properly in `removeIndex` [`#5888` (`https://github.com/sequelize/sequelize/issues/5888`)
- FIXED] `Int4` range not properly parsed [`#5747` (`https://github.com/sequelize/sequelize/issues/5747`)
- FIXED] `upsert` does not fail anymore on not null validations [`#5711` (`https://github.com/sequelize/sequelize/issues/5711`)
- FIXED] Don't remove includes from count queries and unify findAndCount and count queries. [`#6123` (`https://github.com/sequelize/sequelize/issues/6123`)
- [FIXED] `Model.count` with `options.col` and `options.include` works properly now
- FIXED] `bulkCreate` don't map fields to attributes properly [`#4476` (`https://github.com/sequelize/sequelize/issues/4476)[#3908](https://github.com/sequelize/sequelize/issues/3908)[#4103](https://github.com/sequelize/sequelize/issues/4103)[#3764](https://github.com/sequelize/sequelize/issues/3764)[#3789](https://github.com/sequelize/sequelize/issues/3789)[`#4600`](https://github.com/sequelize/sequelize/issues/4600`)
- FIXED] `sync` don't handle global `options.logging` properly [`#5788` (`https://github.com/sequelize/sequelize/issues/5788`)
- FIXED] `attribute:[]` throw errors with `include` or `through` [`#5078`](`https://github.com/sequelize/sequelize/issues/5078`) [`#4222`](`https://github.com/sequelize/sequelize/issues/4222`) [`#5958`](`https://github.com/sequelize/sequelize/issues/5958`) [`#5590`](`https://github.com/sequelize/sequelize/issues/5590`) [`#6139`](`https://github.com/sequelize/sequelize/issues/6139`) [`#4866`](`https://github.com/sequelize/sequelize/issues/4866`) [`#6242` (`https://github.com/sequelize/sequelize/issues/6242`)
- SECURITY] `GEOMETRY` and `GEOGRAPHY` SQL injection attacks [`#6194` (`https://github.com/sequelize/sequelize/issues/6194`)
- FIXED] `DECIMAL` now supports `UNSIGNED` / `ZEROFILL` (MySQL) [`#2038` (`https://github.com/sequelize/sequelize/issues/2038`)
- FIXED] Generate correct SQL of nested include when quoteIdentifiers is false. (Postgres) [`#6351` (`https://github.com/sequelize/sequelize/issues/6351`)
- [FIXED] Generate correct SQL for JSON attributes with quote.
`#6406` (`https://github.com/sequelize/sequelize/issues/6406`)
- FIXED] Nested query return correct result when quoteIdentifiers is false. (Postgres) [`#6363` (`https://github.com/sequelize/sequelize/issues/6363`)
- [FIXED] Fixed an issue where changing multiple ENUM columns in PostgreSQL could break. [`#6203`] (`https://github.com/sequelize/sequelize/issues/6203`)
- [FIXED] Add `parent`, `original` and `sql` properties to `UniqueConstraintError`

#### Version 3.24.1
- [FIXED] Add `parent`, `original` and `sql` properties to `UniqueConstraintError`

#### Version 3.24.0
* feat(model): expose model to global hooks (`#6371`)
* Backport: Add option to restart identity when truncate (`#6417`)
* Use typeof instead of _.isPlainObject (`#6416`)



#### Version 4.0.0-0
This release marks the first in a long line of pre-releases leading up to the release of the final 4.0 version. Expect _at least_ a couple of months before the final release. To get an idea of the set of BC breaks we plan to introduce, see https://github.com/sequelize/sequelize/issues?q=is%3Aopen+is%3Aissue+milestone%3A4.0 (this list is by no means exhaustive).

Two major things have changed in this release:
#### Instances are now `instanceof` their model, instead of being of a separate class
Most notably you can now replace  `User.build()` with `new User()` and `sequelize.define` with `User extends Sequelize.Model` (with the caveat that models defined by extending the `Model` class must still be attached to the sequelize object via `.init`). In the future this quirk can most likely be solved by decorators.

#### Sequelize now only officially supports node v4 and up
This decision has been hard, but we believe that the added features (most notably object literal extensions, template strings and generator coroutines) will be worth the switch. Additionally, cutting down the build matrix and switching coverage from codeclimate to coveralls (which supports parallel coverage jobs - _it's awesome_) has reduced build time from [+30](https://travis-ci.org/sequelize/sequelize/builds/130948203) to [< 10 minutes](https://travis-ci.org/sequelize/sequelize/builds/133325509). In the future we will test against the oldest active [LTS](https://github.com/nodejs/LTS), and the latest version of node.

Various pre-compilers (babel and typescript) were considered, but we have opted not to have a pre-compilation step. The reason for this is twofold; first of all we want to keep the barrier of entry low for new developers, and secondly we want users to be able to install directly from git, which is not possible if the code requires pre-compilation.

The current stable version has been branched out (`https://github.com/sequelize/sequelize/tree/v3`), and we will continue to accept and releases patches. However, do note that all development time from the core team will go towards 4.0.

This, and all future pre-release, will be published under the `unstable` tag on npm. This means that `npm install sequelize` and `npm install sequelize@latest` will still install `v3`. To opt into pre-releases use `npm install sequelize@unstable` or `npm install sequelize@4`.

# What's new in this version (changelog)
- [FIXED] Pass ResourceLock instead of raw connection in MSSQL disconnect handling
- [CHANGED] Remove `hookValidate` in favor of `validate` with `hooks: true | false`.
- [REMOVED] Support for `referencesKey`
- [CHANGED] Throw if `dialect` is not provided to the constructor
- [CHANGED] Throw `bluebird.AggregateError` instead of array from `bulkCreate` when validation fails
- FIXED] `$notIn: []` is now converted to `NOT IN (NULL)`  [`#4859` (`https://github.com/sequelize/sequelize/issues/4859`)
- FIXED] Add `raw` support to `instance.get()` [`#5815` (`https://github.com/sequelize/sequelize/issues/5815`)
- ADDED] Compare deletedAt against current timestamp when using paranoid [`#5880` (`https://github.com/sequelize/sequelize/pull/5880`)
- FIXED] `BIGINT` gets truncated [`#5176` (`https://github.com/sequelize/sequelize/issues/5176`)
- [FIXED] Trigger afterCreate hook after all nested includes (for hasMany or belongsToMany associations) have been created to be consistent with hasOne.
- [REMOVED] Support for `pool:false`
- REMOVED] Default transaction isolation level [`#5094` (`https://github.com/sequelize/sequelize/issues/5094`)
- ADDED] Add logging for mysql warnings, observant of the `showWarnings` option. [`#5900` (`https://github.com/sequelize/sequelize/issues/5900`)
- [REMOVED] MariaDB dialect
- FIXED] `hasOne` now prefer aliases to construct foreign key [`#5247` (`https://github.com/sequelize/sequelize/issues/5247`)
- [CHANGED] `instance.equals` now only checks primary keys, instead of all attributes.
- REWRITE] Rewrite model and instance to a single class - instance instanceof Model [`#5924` (`https://github.com/sequelize/sequelize/issues/5924`)
- [REMOVED] Counter cache plugin
- FIXED] All associations now prefer aliases to construct foreign key [`#5267` (`https://github.com/sequelize/sequelize/issues/5267`)
- REMOVED] Default transaction auto commit [`#5094` (`https://github.com/sequelize/sequelize/issues/5094`)
- REMOVED] Callback support for hooks [`#5228` (`https://github.com/sequelize/sequelize/issues/5228`)

## BC breaks:
- `hookValidate` removed in favor of `validate` with `hooks: true | false`. `validate` returns a promise which is rejected if validation fails
- Removed support for `referencesKey`, use a `references` object
- Remove default dialect
- When `bulkCreate` is rejected because of validation failure it throws a `bluebird.AggregateError` instead of an array. This object is an array-like so length and index access will still work, but `instanceof` array will not
- `$notIn: []` will now match all rows instead of none
- (MySQL) `BIGINT` now gets converted to string when number is too big
- Removed support for `pool:false`, if you still want to use single connection set `pool.max` to `1`
- Removed default `REPEATABLE_READ` transaction isolation, use config option to explicitly set it
- Removed MariaDB dialect - this was just a thin wrapper around MySQL, so using `dialect: 'mysql'` instead should work with no further changes
- `hasOne` now prefer `as` option to generate foreign key name, otherwise it defaults to source model name
- `instance.equals` now provides reference equality (do two instances refer to the same row, i.e. are their primary key(s) equal). Use `instance.get()` to get and compare all values.
- Instances (database rows) are now instances of the model, instead of being a separate class. This means you can replace User.build() with new User() and sequelize.define with User extends Sequelize.Model. See `#5924`
- The counter cache plugin, and consequently the `counterCache` option for associations has been removed. The plugin is seeking a new maintainer - You can find the code here (`https://github.com/sequelize/sequelize/blob/aace1250dfa8cd81a4edfd2086c9058b513f6ee0/lib/plugins/counter-cache.js`)
- All associations type will prefer `as` when constructing the `foreignKey` name. You can override this by `foreignKey` option.
- Removed default `AUTO COMMIT` for transaction. Its only sent if explicitly set by user or required by dialects (like `mysql`)
- Hooks no longer provide a callback - you can return a `then`-able instead if you are doing async stuff

