### PR TITLE
[Doppins] Upgrade dependency babel-eslint to ^7.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   "devDependencies": {
     "babel-cli": "^6.6.5",
     "babel-core": "^6.7.4",
-    "babel-eslint": "^6.0.2",
+    "babel-eslint": "^7.1.0",
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-stage-0": "^6.5.0",
     "chai": "^3.5.0",


### PR DESCRIPTION
Hi!

A new version was just released of `babel-eslint`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded babel-eslint from `^6.0.2` to `^7.1.0`

#### Changelog:

#### Version 7.1.0
v7.1.0

## 🚀 New Feature

- Adding support to lint `dynamicImport` (`#413`) `@kesne` 

Babylon support was added in `https://github.com/babel/babylon/releases/tag/v6.12.0`

```js
import(`./section-modules/${link.dataset.entryModule}.js`)
.then(module => {
  module.loadPageInto(main);
})
```

#### Version 7.0.0
# v7.0.0

## FYI `https://github.com/babel/babel-eslint/issues/88`

We're looking for more contributors maintainers, I don't have as much time to work on babel-eslint since babel needs a lot of help as well).

## Changelog

- Drop node < 4 (`#358`)
- Remove the lodash.assign dependency (`#393`)
- Remove eslint 2 logic (`#361`)
  - Remove logic for accounting for async/await before eslint supported it (`#350`)

ESLint v3.6.0 supports async/await (you don't need always need babel-eslint)

http://eslint.org/blog/2016/09/eslint-v3.6.0-released#support-for-es2017
```js
{
    "parserOptions": {
        "ecmaVersion": 2017,
        "sourceType": "module"
    }
}
```

