### PR TITLE
[Doppins] Upgrade dependency chai-as-promised to ^6.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-stage-0": "^6.5.0",
     "chai": "^3.5.0",
-    "chai-as-promised": "^5.3.0",
+    "chai-as-promised": "^6.0.0",
     "commander": "^2.9.0",
     "eslint": "2.11.1",
     "eslint-config-airbnb": "^9.0.0",


### PR DESCRIPTION
Hi!

A new version was just released of `chai-as-promised`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded chai-as-promised from `^5.3.0` to `^6.0.0`

#### Changelog:

#### Version 6.0.0
In `#167`, `@lddubeau` made many improvements to edge cases that have plagued users:

- Overhauls `rejectedWith` to behave more like Chai's `throws` asserter.
- Updates `.fulfilled`, `.rejected`, and `.rejectedWith` to change the asserter target to the fulfillment value or rejection reason, so that further assertions with `.and` act on them.
- Updates `.fulfilled`, when successful, to return a promise that fulfills with the fulfillment value
- Updates `.rejected` and `.rejectedWith`, when successful, to return a promise that fulfills with the rejection reason

Also, Chai as Promised now only supplies a CommonJS-style module. To get AMD or `<script>`-compatibility, use a bundler tool like [browserify](http://browserify.org/).

