### PR TITLE
[Doppins] Upgrade dependency eslint-plugin-import to ^2.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "eslint": "2.11.1",
     "eslint-config-airbnb": "^9.0.0",
     "eslint-config-webkom": "^1.3.4",
-    "eslint-plugin-import": "^1.6.1",
+    "eslint-plugin-import": "^2.2.0",
     "mocha": "^2.4.5",
     "mongodb": "^2.1.16",
     "nodemailer-stub-transport": "^1.0.0",


### PR DESCRIPTION
Hi!

A new version was just released of `eslint-plugin-import`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded eslint-plugin-import from `^1.6.1` to `^2.2.0`

