### PR TITLE
[Doppins] Upgrade dependency eslint to 3.9.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "chai": "^3.5.0",
     "chai-as-promised": "^5.3.0",
     "commander": "^2.9.0",
-    "eslint": "2.11.1",
+    "eslint": "3.9.1",
     "eslint-config-airbnb": "^9.0.0",
     "eslint-config-webkom": "^1.3.4",
     "eslint-plugin-import": "^1.6.1",


### PR DESCRIPTION
Hi!

A new version was just released of `eslint`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded eslint from `2.11.1` to `3.9.1`

#### Changelog:

#### Version 3.9.1
* 2012258 Fix: incorrect `indent` check for array property access (fixes `#7484`) (`#7485`) (Teddy Katz)
* 8a71d4a Fix: `no-useless-return` false positive on conditionals (fixes `#7477`) (`#7482`) (Teddy Katz)
* 56a662b Fix: allow escaped backreferences in `no-useless-escape` (fixes `#7472`) (`#7474`) (Teddy Katz)
* fffdf13 Build: Fix prefer-reflect rule to not crash site gen build (`#7471`) (Ilya Volodin)
* 8ba68a3 Docs: Update broken link (`#7490`) (Devinsuit)
* 65231d8 Docs: add the "fixable" icon for `no-useless-return` (`#7480`) (Teddy Katz)

#### Version 3.9.0
* d933516 New: `no-useless-return` rule (fixes `#7309`) (`#7441`) (Toru Nagashima)
* 5e7af30 Update: Add `CallExpression` option for `indent` (fixes `#5946`) (`#7189`) (Teddy Katz)
* b200086 Fix: Support type annotations in array-bracket-spacing (`#7445`) (Jimmy Jia)
* 5ed8b9b Update: Deprecate prefer-reflect (fixes `#7226`) (`#7464`) (Kai Cataldo)
* 92ad43b Chore: Update deprecated rules in conf/eslint.json (`#7467`) (Kai Cataldo)
* e46666b New: Codeframe formatter (fixes `#5860`) (`#7437`) (Vitor Balocco)
* fe0d903 Upgrade: Shelljs to ^0.7.5 (fixes `#7316`) (`#7465`) (Gyandeep Singh)
* 1d5146f Update: fix wrong indentation about `catch`,`finally` (`#7371`) (Toru Nagashima)
* 77e3a34 Chore: Pin mock-fs dev dependency (`#7466`) (Gyandeep Singh)
* c675d7d Update: Fix `no-useless-escape` false negative in regexes (fixes `#7424`) (`#7425`) (Teddy Katz)
* ee3bcea Update: add fixer for `newline-after-var` (fixes `#5959`) (`#7375`) (Teddy Katz)
* 6e9ff08 Fix: indent.js to support multiline array statements. (`#7237`) (Scott Stern)
* f8153ad Build: Ensure absolute links in docs retain .md extensions (fixes `#7419`) (`#7438`) (Teddy Katz)
* 16367a8 Fix: Return statement spacing. Fix for indent rule. (fixes `#7164`) (`#7197`) (Imad Elyafi)
* 3813988 Update: fix false negative of `no-extra-parens` (fixes `#7122`) (`#7432`) (Toru Nagashima)
* 23062e2 Docs: Fix typo in no-unexpected-multiline (fixes `#7442`) (`#7447`) (Denis Sikuler)
* d257428 Update: `func-name-matching`: add “nameMatches” option (fixes `#7391`) (`#7428`) (Jordan Harband)
* c710584 Fix: support for MemberExpression with function body. (`#7400`) (Scott Stern)
* 2c8ed2d Build: ensure that all files are linted on bash (fixes `#7426`) (`#7427`) (Teddy Katz)
* 18ff70f Chore: Enable `no-useless-escape` (`#7403`) (Vitor Balocco)
* 8dfd802 Fix: avoid `camelcase` false positive with NewExpressions (fixes `#7363`) (`#7409`) (Teddy Katz)
* e8159b4 Docs: Fix typo and explain static func calls for class-methods-use-this (`#7421`) (Scott O'Hara)
* 85d7e24 Docs: add additional examples for MemberExpressions in Indent rule. (`#7408`) (Scott Stern)
* 2aa1107 Docs: Include note on fatal: true in the node.js api section (`#7376`) (Simen Bekkhus)
* e064a25 Update: add fixer for `arrow-body-style` (`#7240`) (Teddy Katz)
* e0fe727 Update: add fixer for `brace-style` (fixes `#7074`) (`#7347`) (Teddy Katz)
* cbbe420 New: Support enhanced parsers (fixes `#6974`) (`#6975`) (Nicholas C. Zakas)
* 644d25b Update: Add an ignoreRegExpLiterals option to max-len (fixes `#3229`) (`#7346`) (Wilfred Hughes)
* 6875576 Docs: Remove broken links to jslinterrors.com (fixes `#7368`) (`#7369`) (Dannii Willis)

#### Version 3.8.1
* 681c78a Fix: `comma-dangle` was confused by type annotations (fixes `#7370`) (`#7372`) (Toru Nagashima)
* 7525042 Fix: Allow useless escapes in tagged template literals (fixes `#7383`) (`#7384`) (Teddy Katz)
* 9106964 Docs: Fix broken link for stylish formatter (`#7386`) (Vitor Balocco)
* 49d3c1b Docs: Document the deprecated meta property (`#7367`) (Randy Coulman)
* 19d2996 Docs: Relax permission for merging PRs (refs eslint/tsc-meetings`#20`) (`#7360`) (Brandon Mills)

#### Version 3.8.0
* ee60acf Chore: add integration tests for autofixing (fixes `#5909`) (`#7349`) (Teddy Katz)
* c8796e9 Update: `comma-dangle` supports trailing function commas (refs `#7101`) (`#7181`) (Toru Nagashima)
* c4abaf0 Update: `space-before-function-paren` supports async/await (refs `#7101`) (`#7180`) (Toru Nagashima)
* d0d3b28 Fix: id-length rule incorrectly firing on member access (fixes `#6475`) (`#7365`) (Burak Yiğit Kaya)
* 2729d94 Fix: Don't report setter params in class bodies as unused (fixes `#7351`) (`#7352`) (Teddy Katz)
* 0b85004 Chore: Enable prefer-template (fixes `#6407`) (`#7357`) (Kai Cataldo)
* ca1947b Chore: Update pull request template (refs eslint/tsc-meetings`#20`) (`#7359`) (Brandon Mills)
* d840afe Docs: remove broken link from no-loop-func doc (`#7342`) (Michael McDermott)
* 5266793 Update: no-useless-escape checks template literals (fixes `#7331`) (`#7332`) (Kai Cataldo)
* b08fb91 Update: add source property to LintResult object (fixes `#7098`) (`#7304`) (Vitor Balocco)
* 0db4164 Chore: run prefer-template autofixer on test files (refs `#6407`) (`#7354`) (Kai Cataldo)
* c1470b5 Update: Make the `prefer-template` fixer unescape quotes (fixes `#7330`) (`#7334`) (Teddy Katz)
* 5d08c33 Fix: Handle parentheses correctly in `yoda` fixer (fixes `#7326`) (`#7327`) (Teddy Katz)
* cd72bba New: `func-name-matching` rule (fixes `#6065`) (`#7063`) (Annie Zhang)
* 55b5146 Fix: `RuleTester` didn't support `mocha --watch` (`#7287`) (Toru Nagashima)
* f8387c1 Update: add fixer for `prefer-spread` (`#7283`) (Teddy Katz)
* 52da71e Fix: Don't require commas after rest properties (fixes `#7297`) (`#7298`) (Teddy Katz)
* 3b11d3f Chore: refactor `no-multiple-empty-lines` (`#7314`) (Teddy Katz)
* 16d495d Docs: Updating CLI overview with latest changes (`#7335`) (Kevin Partington)
* 52dfce5 Update: add fixer for `one-var-declaration-per-line` (`#7295`) (Teddy Katz)
* 0e994ae Update: Improve the error messages for `no-unused-vars` (fixes `#7282`) (`#7315`) (Teddy Katz)
* 93214aa Chore: Convert non-lib/test files to template literals (refs `#6407`) (`#7329`) (Kai Cataldo)
* 72f394d Update: Fix false negative of `no-multiple-empty-lines` (fixes `#7312`) (`#7313`) (Teddy Katz)
* 756bc5a Update: Use characters instead of code units for `max-len` (`#7299`) (Teddy Katz)
* c9a7ec5 Fix: Improving optionator configuration for --print-config (`#7206`) (Kevin Partington)
* 51bfade Fix: avoid `object-shorthand` crash with spread properties (fixes `#7305`) (`#7306`) (Teddy Katz)
* a12d1a9 Update: add fixer for `no-lonely-if` (`#7202`) (Teddy Katz)
* 1418384 Fix: Don't require semicolons before `++`/`--` (`#7252`) (Adrian Heine né Lang)
* 2ffe516 Update: add fixer for `curly` (`#7105`) (Teddy Katz)
* ac3504d Update: add functionPrototypeMethods to wrap-iife (fixes `#7212`) (`#7284`) (Eli White)
* 5e16fb4 Update: add fixer for `no-extra-bind` (`#7236`) (Teddy Katz)

#### Version 3.7.1
* 3dcae13 Fix: Use the correct location for `comma-dangle` errors (fixes `#7291`) (`#7292`) (Teddy Katz)
* cb7ba6d Fix: no-implicit-coercion should not fix ~. (fixes `#7272`) (`#7289`) (Eli White)
* ce590e2 Chore: Add additional tests for bin/eslint.js (`#7290`) (Teddy Katz)
* 8ec82ee Docs: change links of templates to raw data (`#7288`) (Toru Nagashima)

#### Version 3.7.0
* 2fee8ad Fix: object-shorthand's consistent-as-needed option (issue `#7214`) (`#7215`) (Naomi Jacobs)
* c05a19c Update: add fixer for `prefer-numeric-literals` (`#7205`) (Teddy Katz)
* 2f171f3 Update: add fixer for `no-undef-init` (`#7210`) (Teddy Katz)
* 876d747 Docs: Steps for adding new committers/TSCers (`#7221`) (Nicholas C. Zakas)
* dffb4fa Fix: `no-unused-vars` false positive (fixes `#7250`) (`#7258`) (Toru Nagashima)
* 4448cec Docs: Adding missing ES8 reference to configuring (`#7271`) (Kevin Partington)
* 332d213 Update: Ensure `indent` handles nested functions correctly (fixes `#7249`) (`#7265`) (Teddy Katz)
* c36d842 Update: add fixer for `no-useless-computed-key` (`#7207`) (Teddy Katz)
* 18376cf Update: add fixer for `lines-around-directive` (`#7217`) (Teddy Katz)
* f8e8fab Update: add fixer for `wrap-iife` (`#7196`) (Teddy Katz)
* 558b444 Docs: Add `@not-an-aardvark` to development team (`#7279`) (Ilya Volodin)
* cd1dc57 Update: Add a fixer for `dot-location` (`#7186`) (Teddy Katz)
* 89787b2 Update: for `yoda`, add a fixer (`#7199`) (Teddy Katz)
* 742ae67 Fix: avoid indent and no-mixed-spaces-and-tabs conflicts (fixes `#7248`) (`#7266`) (Teddy Katz)
* 85b8714 Fix: Use error templates even when reading from stdin (fixes `#7213`) (`#7223`) (Teddy Katz)
* 66adac1 Docs: correction in prefer-reflect docs (fixes `#7069`) (`#7150`) (Scott Stern)
* e3f95de Update: Fix `no-extra-parens` false negative (fixes `#7229`) (`#7231`) (Teddy Katz)
* 2909c19 Docs: Fix typo in object-shorthand docs (`#7267`) (Brian Donovan)
* 7bb800d Chore: add internal rule to enforce meta.docs conventions (fixes `#6954`) (`#7155`) (Vitor Balocco)
* 722c68c Docs: add code fences to the issue template (`#7254`) (Teddy Katz)

#### Version 3.6.1
* b467436 Upgrade: Upgrade Espree to 3.3.1 (`#7253`) (Ilya Volodin)
* 299a563 Build: Do not strip .md extension from absolute URLs (`#7222`) (Kai Cataldo)
* 27042d2 Chore: removed unused code related to scopeMap (`#7218`) (Yang Su)
* d154204 Chore: Lint bin/eslint.js (`#7243`) (Kevin Partington)
* 87625fa Docs: Improve eol-last examples in docs (`#7227`) (Chainarong Tangsurakit)
* de8eaa4 Docs: `class-methods-use-this`: fix option name (`#7224`) (Jordan Harband)
* 2355f8d Docs: Add Brunch plugin to integrations (`#7225`) (Aleksey Shvayka)
* a5817ae Docs: Default option from `operator-linebreak` is `after`and not always (`#7228`) (Konstantin Pschera)

#### Version 3.6.0
* 1b05d9c Update: add fixer for `strict` (fixes `#6668`) (`#7198`) (Teddy Katz)
* 0a36138 Docs: Update ecmaVersion instructions (`#7195`) (Nicholas C. Zakas)
* aaa3779 Update: Allow `space-unary-ops` to handle await expressions (`#7174`) (Teddy Katz)
* 91bf477 Update: add fixer for `prefer-template` (fixes `#6978`) (`#7165`) (Teddy Katz)
* 745343f Update: `no-extra-parens` supports async/await (refs `#7101`) (`#7178`) (Toru Nagashima)
* 8e1fee1 Fix: Handle number literals correctly in `no-whitespace-before-property` (`#7185`) (Teddy Katz)
* 462a3f7 Update: `keyword-spacing` supports async/await (refs `#7101`) (`#7179`) (Toru Nagashima)
* 709a734 Update: Allow template string in `valid-typeof` comparison (fixes `#7166`) (`#7168`) (Teddy Katz)
* f71937a Fix: Don't report async/generator callbacks in `array-callback-return` (`#7172`) (Teddy Katz)
* 461b015 Fix: Handle async functions correctly in `prefer-arrow-callback` fixer (`#7173`) (Teddy Katz)
* 7ea3e4b Fix: Handle await expressions correctly in `no-unused-expressions` (`#7175`) (Teddy Katz)
* 16bb802 Update: Ensure `arrow-parens` handles async arrow functions correctly (`#7176`) (Teddy Katz)
* 2d10657 Chore: add tests for `generator-star-spacing` and async (refs `#7101`) (`#7182`) (Toru Nagashima)
* c118d21 Update: Let `no-restricted-properties` check destructuring (fixes `#7147`) (`#7151`) (Teddy Katz)
* 9e0b068 Fix: valid-jsdoc does not throw on FieldType without value (fixes `#7184`) (`#7187`) (Kai Cataldo)
* 4b5d9b7 Docs: Update process for evaluating proposals (fixes `#7156`) (`#7183`) (Kai Cataldo)
* 95c777a Update: Make `no-restricted-properties` more flexible (fixes `#7137`) (`#7139`) (Teddy Katz)
* 0fdf23c Update: fix `quotes` rule's false negative (fixes `#7084`) (`#7141`) (Toru Nagashima)
* f2a789d Update: fix `no-unused-vars` false negative (fixes `#7124`) (`#7143`) (Toru Nagashima)
* 6148d85 Fix: Report columns for `eol-last` correctly (fixes `#7136`) (`#7149`) (kdex)
* e016384 Update: add fixer for quote-props (fixes `#6996`) (`#7095`) (Teddy Katz)
* 35f7be9 Upgrade: espree to 3.2.0, remove tests with SyntaxErrors (fixes `#7169`) (`#7170`) (Teddy Katz)
* 28ddcf8 Fix: `max-len`: `ignoreTemplateLiterals`: handle 3+ lines (fixes `#7125`) (`#7138`) (Jordan Harband)
* 660e091 Docs: Update rule descriptions (fixes `#5912`) (`#7152`) (Kenneth Williams)
* 8b3fc32 Update: Make `indent` report lines with mixed spaces/tabs (fixes `#4274`) (`#7076`) (Teddy Katz)
* b39ac2c Update: add fixer for `no-regex-spaces` (`#7113`) (Teddy Katz)
* cc80467 Docs: Update PR templates for formatting (`#7128`) (Nicholas C. Zakas)
* 76acbb5 Fix: include LogicalExpression in indent length calc  (fixes `#6731`) (`#7087`) (Alec)
* a876673 Update: no-implicit-coercion checks TemplateLiterals (fixes `#7062`) (`#7121`) (Kai Cataldo)
* 8db4f0c Chore: Enable `typeof` check for `no-undef` rule in eslint-config-eslint (`#7103`) (Teddy Katz)
* 7e8316f Docs: Update release process (`#7127`) (Nicholas C. Zakas)
* 22edd8a Update: `class-methods-use-this`: `exceptions` option (fixes `#7085`) (`#7120`) (Jordan Harband)
* afd132a Fix: line-comment-position "above" string option now works (fixes `#7100`) (`#7102`) (Kevin Partington)
* 1738b2e Chore: fix name of internal-no-invalid-meta test file (`#7142`) (Vitor Balocco)
* ac0bb62 Docs: Fixes examples for allowTemplateLiterals (fixes `#7115`) (`#7135`) (Zoe Ingram)
* bcfa3e5 Update: Add `always`/`never` option to `eol-last` (fixes `#6938`) (`#6952`) (kdex)
* 0ca26d9 Docs: Distinguish examples for space-before-blocks (`#7132`) (Timo Tijhof)
* 9a2aefb Chore: Don't require an issue reference in check-commit npm script (`#7104`) (Teddy Katz)
* c85fd84 Fix: max-statements-per-line rule to force minimum to be 1 (fixes `#7051`) (`#7092`) (Scott Stern)
* e462e47 Docs: updates category of no-restricted-properties (fixes `#7112`) (`#7118`) (Alec)
* 6ae660b Fix: Don't report comparisons of two typeof expressions (fixes `#7078`) (`#7082`) (Teddy Katz)
* 710f205 Docs: Fix typos in Issues section of Maintainer's Guide (`#7114`) (Kai Cataldo)
* 546a3ca Docs: Clarify that linter does not process configuration (fixes `#7108`) (`#7110`) (Kevin Partington)
* 0d50943 Docs: Elaborate on `guard-for-in` best practice (fixes `#7071`) (`#7094`) (Dallon Feldner)
* 58e6d76 Docs: Fix examples for no-restricted-properties (`#7099`) (not-an-aardvark)
* 6cfe519 Docs: Corrected typo in line-comment-position rule doc (`#7097`) (Alex Mercier)
* f02e52a Docs: Add fixable note to no-implicit-coercion docs (`#7096`) (Brandon Mills)

#### Version 3.5.0
* 08fa538 Update: fix false negative of `arrow-spacing` (fixes `#7079`) (`#7080`) (Toru Nagashima)
* cec65e3 Update: add fixer for no-floating-decimal (fixes `#7070`) (`#7081`) (not-an-aardvark)
* 2a3f699 Fix: Column number for no-multiple-empty-lines (fixes `#7086`) (`#7088`) (Ian VanSchooten)
* 6947299 Docs: Add info about closing accepted issues to docs (fixes `#6979`) (`#7089`) (Kai Cataldo)
* d30157a Docs: Add link to awesome-eslint in integrations page (`#7090`) (Vitor Balocco)
* 457be1b Docs: Update so issues are not required (fixes `#7015`) (`#7072`) (Nicholas C. Zakas)
* d9513b7 Fix: Allow linting of .hidden files/folders (fixes `#4828`) (`#6844`) (Ian VanSchooten)
* 6d97c18 New: `max-len`: `ignoreStrings`+`ignoreTemplateLiterals` (fixes `#5805`) (`#7049`) (Jordan Harband)
* 538d258 Update: make no-implicit-coercion support autofixing. (fixes `#7056`) (`#7061`) (Eli White)
* 883316d Update: add fixer for prefer-arrow-callback (fixes `#7002`) (`#7004`) (not-an-aardvark)
* 7502eed Update: auto-fix for `comma-style` (fixes `#6941`) (`#6957`) (Gyandeep Singh)
* 645dda5 Update: add fixer for dot-notation (fixes `#7014`) (`#7054`) (not-an-aardvark)
* 2657846 Fix: `no-console` ignores user-defined console (fixes `#7010`) (`#7058`) (Toru Nagashima)
* 656bb6e Update: add fixer for newline-before-return (fixes `#5958`) (`#7050`) (Vitor Balocco)
* 1f995c3 Fix: no-implicit-coercion string concat false positive (fixes `#7057`) (`#7060`) (Kai Cataldo)
* 6718749 Docs: Clarify that `es6` env also sets `ecmaVersion` to 6 (`#7067`) (Jérémie Astori)
* e118728 Update: add fixer for wrap-regex (fixes `#7013`) (`#7048`) (not-an-aardvark)
* f4fcd1e Update: add more `indent` options for functions (fixes `#6052`) (`#7043`) (not-an-aardvark)
* 657eee5 Update: add fixer for new-parens (fixes `#6994`) (`#7047`) (not-an-aardvark)
* ff19aa9 Update: improve `max-statements-per-line` message (fixes `#6287`) (`#7044`) (Jordan Harband)
* 3960617 New: `prefer-numeric-literals` rule (fixes `#6068`) (`#7029`) (Annie Zhang)
* fa760f9 Chore: no-regex-spaces uses internal rule message format (fixes `#7052`) (`#7053`) (Kevin Partington)
* 22c7e09 Update: no-magic-numbers false negative on reassigned vars (fixes `#4616`) (`#7028`) (not-an-aardvark)
* be29599 Update: Throw error if whitespace found in plugin name (fixes `#6854`) (`#6960`) (Jesse Ostrander)
* 4063a79 Fix: Rule message placeholders can be inside braces (fixes `#6988`) (`#7041`) (Kevin Partington)
* 52e8d9c Docs: Clean up sort-vars (`#7045`) (Matthew Dunsdon)
* 4126f12 Chore: Rule messages use internal rule message format (fixes `#6977`) (`#6989`) (Kevin Partington)
* 46cb690 New: `no-restricted-properties` rule (fixes `#3218`) (`#7017`) (Eli White)
* 00b3042 Update: Pass file path to parse function (fixes `#5344`) (`#7024`) (Annie Zhang)
* 3f13325 Docs: Add kaicataldo and JamesHenry to our teams (`#7039`) (alberto)
* 8e77f16 Update: `new-parens` false negative (fixes `#6997`) (`#6999`) (Toru Nagashima)
* 326f457 Docs: Add missing 'to' in no-restricted-modules (`#7022`) (Oskar Risberg)
* 8277357 New: `line-comment-position` rule (fixes `#6077`) (`#6953`) (alberto)
* c1f0d76 New: `lines-around-directive` rule (fixes `#6069`) (`#6998`) (Kai Cataldo)
* 61f1de0 Docs: Fix typo in no-debugger (`#7019`) (Denis Ciccale)
* 256c4a2 Fix: Allow separate mode option for multiline and align (fixes `#6691`) (`#6991`) (Annie Zhang)
* a989a7c Docs: Declaring dependency on eslint in shared config (fixes `#6617`) (`#6985`) (alberto)
* 6869c60 Docs: Fix minor typo in no-extra-parens doc (`#6992`) (Jérémie Astori)
* 28f1619 Docs: Update the example of SwitchCase (`#6981`) (fish)

#### Version 3.4.0
* c210510 Update: add fixer for no-extra-parens (fixes `#6944`) (`#6950`) (not-an-aardvark)
* ca3d448 Fix: `prefer-const` false negative about `eslintUsed` (fixes `#5837`) (`#6971`) (Toru Nagashima)
* 1153955 Docs: Draft of JSCS migration guide (refs `#5859`) (`#6942`) (Nicholas C. Zakas)
* 3e522be Fix: false negative of `indent` with `else if` statements (fixes `#6956`) (`#6965`) (not-an-aardvark)
* 2dfb290 Docs: Distinguish examples in rules under Stylistic Issues part 7 (`#6760`) (Kenneth Williams)
* 3c710c9 Fix: rename "AirBnB" => "Airbnb" init choice (fixes `#6969`) (Harrison Shoff)
* 7660b39 Fix: `object-curly-spacing` for type annotations (fixes `#6940`) (`#6945`) (Toru Nagashima)
* 21ab784 New: do not remove non visited files from cache. (fixes `#6780`) (`#6921`) (Roy Riojas)
* 3a1763c Fix: enable ``@scope`/plugin/ruleId`-style specifier (refs `#6362`) (`#6939`) (Toru Nagashima)
* d6fd064 Update: Add never option to multiline-ternary (fixes `#6751`) (`#6905`) (Kai Cataldo)
* 0d268f1 New: `symbol-description` rule (fixes `#6778`) (`#6825`) (Jarek Rencz)
* a063d4e Fix: no-cond-assign within a function expression (fixes `#6908`) (`#6909`) (Patrick McElhaney)
* 16db93a Build: Tag docs, publish release notes (fixes `#6892`) (`#6934`) (Nicholas C. Zakas)
* 0cf1d55 Chore: Fix object-shorthand errors (fixes `#6958`) (`#6959`) (Kai Cataldo)
* 8851ddd Fix: Improve pref of globbing by inheriting glob.GlobSync (fixes `#6710`) (`#6783`) (Kael Zhang)
* cf2242c Update: `requireStringLiterals` option for `valid-typeof` (fixes `#6698`) (`#6923`) (not-an-aardvark)
* 8561389 Fix: `no-trailing-spaces` wrong fixing (fixes `#6933`) (`#6937`) (Toru Nagashima)
* 6a92be5 Docs: Update semantic versioning policy (`#6935`) (alberto)
* a5189a6 New: `class-methods-use-this` rule (fixes `#5139`) (`#6881`) (Gyandeep Singh)
* 1563808 Update: add support for ecmaVersion 20xx (fixes `#6750`) (`#6907`) (Kai Cataldo)
* d8b770c Docs: Change rule descriptions for consistent casing (`#6915`) (Brandon Mills)
* c676322 Chore: Use object-shorthand batch 3 (refs `#6407`) (`#6914`) (Kai Cataldo)

#### Version 3.3.1
* a2f06be Build: optimize rule page title for small browser tabs (fixes `#6888`) (`#6904`) (Vitor Balocco)
* 02a00d6 Docs: clarify rule details for no-template-curly-in-string (`#6900`) (not-an-aardvark)
* b9b3446 Fix: sort-keys ignores destructuring patterns (fixes `#6896`) (`#6899`) (Kai Cataldo)
* 3fe3a4f Docs: Update options in `object-shorthand` (`#6898`) (Grant Snodgrass)
* cd09c96 Chore: Use object-shorthand batch 2 (refs `#6407`) (`#6897`) (Kai Cataldo)
* 2841008 Chore: Use object-shorthand batch 1 (refs `#6407`) (`#6893`) (Kai Cataldo)

#### Version 3.3.0
* 683ac56 Build: Add CI release scripts (fixes `#6884`) (`#6885`) (Nicholas C. Zakas)
* ebf8441 Update: `prefer-rest-params` relax for member accesses (fixes `#5990`) (`#6871`) (Toru Nagashima)
* df01c4f Update: Add regex support for exceptions (fixes `#5187`) (`#6883`) (Annie Zhang)
* 055742c Fix: `no-dupe-keys` type errors (fixes `#6886`) (`#6889`) (Toru Nagashima)
* e456fd3 New: `sort-keys` rule (fixes `#6076`) (`#6800`) (Toru Nagashima)
* 3e879fc Update: Rule "eqeqeq" to have more specific null handling (fixes `#6543`) (`#6849`) (Simon Sturmer)
* e8cb7f9 Chore: use eslint-plugin-node (refs `#6407`) (`#6862`) (Toru Nagashima)
* e37bbd8 Docs: Remove duplicate statement (`#6878`) (Richard Käll)
* 11395ca Fix: `no-dupe-keys` false negative (fixes `#6801`) (`#6863`) (Toru Nagashima)
* 1ecd2a3 Update: improve error message in `no-control-regex` (`#6839`) (Jordan Harband)
* d610d6c Update: make `max-lines` report the actual number of lines (fixes `#6766`) (`#6764`) (Jarek Rencz)
* b256c50 Chore: Fix glob for core js files for lint (fixes `#6870`) (`#6872`) (Gyandeep Singh)
* f8ab8f1 New: func-call-spacing rule (fixes `#6080`) (`#6749`) (Brandon Mills)
* be68f0b New: no-template-curly-in-string rule (fixes `#6186`) (`#6767`) (Jeroen Engels)
* 80789ab Chore: don't throw if rule is in old format (fixes `#6848`) (`#6850`) (Vitor Balocco)
* d47c505 Fix: `newline-after-var` false positive (fixes `#6834`) (`#6847`) (Toru Nagashima)
* bf0afcb Update: validate void operator in no-constant-condition (fixes `#5726`) (`#6837`) (Vitor Balocco)
* 5ef839e New: Add consistent and ..-as-needed to object-shorthand (fixes `#5438`) (`#5439`) (Martijn de Haan)
* 7e1bf01 Fix: update peerDependencies of airbnb option for `--init` (fixes `#6843`) (`#6846`) (Vitor Balocco)
* 8581f4f Fix: `no-invalid-this` false positive (fixes `#6824`) (`#6827`) (Toru Nagashima)
* 90f78f4 Update: add `props` option to `no-self-assign` rule (fixes `#6718`) (`#6721`) (Toru Nagashima)
* 30d71d6 Update: 'requireForBlockBody' modifier for 'arrow-parens' (fixes `#6557`) (`#6558`) (Nicolas Froidure)
* cdded07 Chore: use native `Object.assign` (refs `#6407`) (`#6832`) (Gyandeep Singh)
* 579ec49 Chore: Add link to rule change guidelines in "needs info" template (fixes `#6829`) (`#6831`) (Kevin Partington)
* 117e7aa Docs: Remove incorrect "constructor" statement from `no-new-symbol` docs (`#6830`) (Jarek Rencz)
* aef18b4 New: `no-unsafe-negation` rule (fixes `#2716`) (`#6789`) (Toru Nagashima)
* d94e945 Docs: Update Getting Started w/ Readme installation instructions (`#6823`) (Kai Cataldo)
* dfbc112 Upgrade: proxyquire to 1.7.10 (fixes `#6821`) (`#6822`) (alberto)
* 4c5e911 Chore: enable `prefer-const` and apply it to our codebase (refs `#6407`) (`#6805`) (Toru Nagashima)
* e524d16 Update: camelcase rule fix for import declarations (fixes `#6755`) (`#6784`) (Lorenzo Zottar)
* 8f3509d Update: make `eslint:all` excluding deprecated rules (fixes `#6734`) (`#6756`) (Toru Nagashima)
* 2b17459 New: `no-global-assign` rule (fixes `#6586`) (`#6746`) (alberto)

#### Version 3.2.2

* 510ce4b Upgrade: file-entry-cache@^1.3.1 (fixes `#6816`, refs `#6780`) (`#6819`) (alberto)
* 46b14cd Fix: ignore MemberExpression in VariableDeclarators (fixes `#6795`) (`#6815`) (Nicholas C. Zakas)

#### Version 3.2.1
* 584577a Build: Pin file-entry-cache to avoid licence issue (refs `#6816`) (`#6818`) (alberto)
* 38d0d23 Docs: clarify minor releases and suggest using `~ to version (`#6804`) (Henry Zhu)
* 4ca809e Fix: Normalizes messages so all end with a period (fixes `#6762`) (`#6807`) (Patrick McElhaney)
* c7488ac Fix: Make MemberExpression option opt-in (fixes `#6797`) (`#6798`) (Rich Trott)
* 715e8fa Docs: Update issue closing policy (fixes `#6765`) (`#6808`) (Nicholas C. Zakas)
* 288f7bf Build: Fix site generation (fixes `#6791`) (`#6793`) (Nicholas C. Zakas)
* 261a9f3 Docs: Update JSCS status in README (`#6802`) (alberto)
* 5ae0887 Docs: Update no-void.md (`#6799`) (Daniel Hritzkiv)

#### Version 3.2.0
* 2438ee2 Upgrade: Update markdownlint dependency to 0.2.0 (fixes `#6781`) (`#6782`) (David Anson)
* 4fc0018 Chore: dogfooding `no-var` rule and remove `var`s (refs `#6407`) (`#6757`) (Toru Nagashima)
* b22eb5c New: `no-tabs` rule (fixes `#6079`) (`#6772`) (Gyandeep Singh)
* ddea63a Chore: Updated no-control-regex tests to cover all cases (fixes `#6438`) (`#6752`) (Efe Gürkan YALAMAN)
* 1025772 Docs: Add plugin example to disabling with comments guide (fixes `#6742`) (`#6747`) (Brandon Mills)
* 628aae4 Docs: fix inconsistent spacing inside block comment (`#6768`) (Brian Jacobel)
* 2983c32 Docs: Add options to func-names config comments (`#6748`) (Brandon Mills)
* 2f94443 Docs: fix wrong path (`#6763`) (molee1905)
* 6f3faa4 Revert "Build: Remove support for Node v5 (fixes `#6743`)" (`#6758`) (Nicholas C. Zakas)
* 99dfd1c Docs: fix grammar issue in rule-changes page (`#6761`) (Vitor Balocco)
* e825458 Fix: Rule no-unused-vars had missing period (fixes `#6738`) (`#6739`) (Brian Mock)
* 71ae64c Docs: Clarify cache file deletion (fixes `#4943`) (`#6712`) (Nicholas C. Zakas)
* 26c85dd Update: merge warnings of consecutive unreachable nodes (fixes `#6583`) (`#6729`) (Toru Nagashima)
* 106e40b Fix: Correct grammar in object-curly-newline reports (fixes `#6725`) (`#6728`) (Vitor Balocco)
* e00754c Chore: Dogfooding ES6 rules (refs `#6407`) (`#6735`) (alberto)
* 181b26a Build: Remove support for Node v5 (fixes `#6743`) (`#6744`) (alberto)
* 5320a6c Update: `no-use-before-define` false negative on for-in/of (fixes `#6699`) (`#6719`) (Toru Nagashima)
* a2090cb Fix: space-infix-ops doesn't fail for  type annotations(fixes `#5211`) (`#6723`) (Nicholas C. Zakas)
* 9c36ecf Docs: Add `@vitorbal` and `@platinumazure` to development team (Ilya Volodin)
* e09d1b8 Docs: describe all RuleTester options (fixes `#4810`, fixes `#6709`) (`#6711`) (Nicholas C. Zakas)
* a157f47 Chore: Update CLIEngine option desc (fixes `#5179`) (`#6713`) (Nicholas C. Zakas)
* a0727f9 Chore: fix `.gitignore` for vscode (refs `#6383`) (`#6720`) (Toru Nagashima)
* 75d2d43 Docs: Clarify Closure type hint expectation (fixes `#5231`) (`#6714`) (Nicholas C. Zakas)
* 95ea25a Update: Check indentation of multi-line chained properties (refs `#1801`) (`#5940`) (Rich Trott)
* e7b1e1c Docs: Edit issue/PR waiting period docs (fixes `#6009`) (`#6715`) (Nicholas C. Zakas)
* 053aa0c Update: Added 'allowSuper' option to `no-underscore-dangle` (fixes `#6355`) (`#6662`) (peteward44)
* 8929045 Build: Automatically generate rule index (refs `#2860`) (`#6658`) (Ilya Volodin)
* f916ae5 Docs: Fix multiline-ternary typos (`#6704`) (Cédric Malard)
* c64b0c2 Chore: First ES6 refactoring (refs `#6407`) (`#6570`) (Nicholas C. Zakas)

#### Version 3.1.1
* 565e584 Fix: `eslint:all` causes regression in 3.1.0 (fixes `#6687`) (`#6696`) (alberto)
* cb90359 Fix: Allow named recursive functions (fixes `#6616`) (`#6667`) (alberto)
* 3f206dd Fix: `balanced` false positive in `spaced-comment` (fixes `#6689`) (`#6692`) (Grant Snodgrass)
* 57f1676 Docs: Add missing brackets from code examples (`#6700`) (Plusb Preco)
* 124f066 Chore: Remove fixable key from multiline-ternary metadata (fixes `#6683`) (`#6688`) (Kai Cataldo)
* 9f96086 Fix: Escape control characters in XML. (fixes `#6673`) (`#6672`) (George Chung)

#### Version 3.1.0
* e8f8c6c Fix: incorrect exitCode when eslint is called with --stdin (fixes `#6677`) (`#6682`) (Steven Humphrey)
* 38639bf Update: make `no-var` fixable (fixes `#6639`) (`#6644`) (Toru Nagashima)
* dfc20e9 Fix: `no-unused-vars` false positive in loop (fixes `#6646`) (`#6649`) (Toru Nagashima)
* 2ba75d5 Update: relax outerIIFEBody definition (fixes `#6613`) (`#6653`) (Stephen E. Baker)
* 421e4bf Chore: combine multiple RegEx replaces with one (fixes `#6669`) (`#6661`) (Sakthipriyan Vairamani)
* 089ee2c Docs: fix typos,wrong path,backticks (`#6663`) (molee1905)
* ef827d2 Docs: Add another pre-commit hook to integrations (`#6666`) (David Alan Hjelle)
* a343b3c Docs: Fix option typo in no-underscore-dangle (Fixes `#6674`) (`#6675`) (Luke Page)
* 5985eb2 Chore: add internal rule that validates meta property (fixes `#6383`) (`#6608`) (Vitor Balocco)
* 4adb15f Update: Add `balanced` option to `spaced-comment` (fixes `#4133`) (`#6575`) (Annie Zhang)
* 1b13c25 Docs: fix incorrect example being mark as correct (`#6660`) (David Björklund)
* a8b4e40 Fix: Install required eslint plugin for "standard" guide (fixes `#6656`) (`#6657`) (Feross Aboukhadijeh)
* 720686b New: `endLine` and `endColumn` of the lint result. (refs `#3307`) (`#6640`) (Toru Nagashima)
* 54faa46 Docs: Small tweaks to CLI documentation (fixes `#6627`) (`#6642`) (Kevin Partington)
* e108850 Docs: Added examples and structure to `padded-blocks` (fixes `#6628`) (`#6643`) (alberto)
* 350e1c0 Docs: Typo (`#6650`) (Peter Rood)
* b837c92 Docs: Correct a term in max-len.md (fixes `#6637`) (`#6641`) (Vse Mozhet Byt)
* baeb313 Fix: Warning behavior for executeOnText (fixes `#6611`) (`#6632`) (Nicholas C. Zakas)
* e6004be Chore: Enable preferType in valid-jsdoc (refs `#5188`) (`#6634`) (Nicholas C. Zakas)
* ca323cf Fix: Use default assertion messages (fixes `#6532`) (`#6615`) (Dmitrii Abramov)
* 2bdf22c Fix: Do not throw exception if baseConfig is provided (fixes `#6605`) (`#6625`) (Kevin Partington)
* e42cacb Upgrade: mock-fs to 3.10, fixes for Node 6.3 (fixes `#6621`) (`#6624`) (Tim Schaub)
* 8a263ae New: multiline-ternary rule (fixes `#6066`) (`#6590`) (Kai Cataldo)
* e951303 Update: Adding new `key-spacing` option (fixes `#5613`) (`#5907`) (Kyle Mendes)
* 10c3e91 Docs: Remove reference from 3.0.0 migration guide (refs `#6605`) (`#6618`) (Kevin Partington)
* 5010694 Docs: Removed non-existing resource (`#6609`) (Moritz Kröger)
* 6d40d85 Docs: Note that PR requires ACCEPTED issue (refs `#6568`) (`#6604`) (Patrick McElhaney)

#### Version 3.0.1
* 27700cf Fix: `no-unused-vars` false positive around callback (fixes `#6576`) (`#6579`) (Toru Nagashima)
* 124d8a3 Docs: Pull request template (`#6568`) (Nicholas C. Zakas)
* e9a2ed9 Docs: Fix rules\id-length exceptions typos (fixes `#6397`) (`#6593`) (GramParallelo)
* a2cfa1b Fix: Make outerIIFEBody work correctly (fixes `#6585`) (`#6596`) (Nicholas C. Zakas)
* 9c451a2 Docs: Use string severity in example (`#6601`) (Kenneth Williams)
* 8308c0b Chore: remove path-is-absolute in favor of the built-in (fixes `#6598`) (`#6600`) (shinnn)
* 7a63717 Docs: Add missing pull request step (fixes `#6595`) (`#6597`) (Nicholas C. Zakas)
* de3ed84 Fix: make `no-unused-vars` ignore for-in (fixes `#2342`) (`#6126`) (Oleg Gaidarenko)
* 6ef2cbe Fix: strip Unicode BOM of config files (fixes `#6556`) (`#6580`) (Toru Nagashima)
* ee7fcfa Docs: Correct type of `outerIIFEBody` in `indent` (fixes `#6581`) (`#6584`) (alberto)
* 25fc7b7 Fix: false negative of `max-len` (fixes `#6564`) (`#6565`) (not-an-aardvark)
* f6b8452 Docs: Distinguish examples in rules under Stylistic Issues part 6 (`#6567`) (Kenneth Williams)

#### Version 3.0.0

* 66de9d8 Docs: Update installation instructions on README (`#6569`) (Nicholas C. Zakas)
* dc5b78b Breaking: Add `require-yield` rule to `eslint:recommended` (fixes `#6550`) (`#6554`) (Gyandeep Singh)
* 7988427 Fix: lib/config.js tests pass if personal config exists (fixes `#6559`) (`#6566`) (Kevin Partington)
* 4c05967 Docs: Update rule docs for new format (fixes `#5417`) (`#6551`) (Nicholas C. Zakas)
* 70da5a8 Docs: Correct link to rules page (#fixes 6553) (`#6561`) (alberto)
* e2b2030 Update: Check RegExp strings for `no-regex-spaces` (fixes `#3586`) (`#6379`) (Jackson Ray Hamilton)
* 397e51b Update: Implement outerIIFEBody for indent rule (fixes `#6259`) (`#6382`) (David Shepherd)
* 666da7c Docs: 3.0.0 migration guide (`#6521`) (Nicholas C. Zakas)
* b9bf8fb Docs: Update Governance Policy (fixes `#6452`) (`#6522`) (Nicholas C. Zakas)
* 1290657 Update: `no-unused-vars` ignores read it modifies itself (fixes `#6348`) (`#6535`) (Toru Nagashima)
* d601f6b Fix: Delete cache only when executing on files (fixes `#6459`) (`#6540`) (Kai Cataldo)
* e0d4b19 Breaking: Error thrown/printed if no config found (fixes `#5987`) (`#6538`) (Kevin Partington)
* 18663d4 Fix: false negative of `no-useless-rename` (fixes `#6502`) (`#6506`) (Toru Nagashima)
* 0a7936d Update: Add fixer for prefer-const (fixes `#6448`) (`#6486`) (Nick Heiner)
* c60341f Chore: Update index and `meta` for `"eslint:recommended"` (refs `#6403`) (`#6539`) (Mark Pedrotti)
* 73da28d Better wording for the error reported by the rule "no-else-return" `#6411` (`#6413`) (Olivier Thomann)
* e06a5b5 Update: Add fixer for arrow-parens (fixes `#4766`) (`#6501`) (madmed88)
* 5f8f3e8 Docs: Remove Box as a sponsor (`#6529`) (Nicholas C. Zakas)
* 7dfe0ad Docs: fix max-lines samples (fixes `#6516`) (`#6515`) (Dmitriy Shekhovtsov)
* fa05119 Breaking: Update eslint:recommended (fixes `#6403`) (`#6509`) (Nicholas C. Zakas)
* e96177b Docs: Add "Proposing a Rule Change" link to CONTRIBUTING.md (`#6511`) (Kevin Partington)
* bea9096 Docs: Update pull request steps (fixes `#6474`) (`#6510`) (Nicholas C. Zakas)
* 7bcf6e0 Docs: Consistent example headings & text pt3 (refs `#5446`) (`#6492`) (Guy Fraser)
* 1a328d9 Docs: Consistent example headings & text pt4 (refs `#5446`) (`#6493`) (Guy Fraser)
* ff5765e Docs: Consistent example headings & text pt2 (refs `#5446`)(`#6491`) (Guy Fraser)
* 01384fa Docs: Fixing typos (refs `#5446`)(`#6494`) (Guy Fraser)
* 4343ae8 Fix: false negative of `object-shorthand` (fixes `#6429`) (`#6434`) (Toru Nagashima)
* b7d8c7d Docs: more accurate yoda-speak (`#6497`) (Tony Lukasavage)
* 3b0ab0d Fix: add warnIgnored flag to CLIEngine.executeOnText (fixes `#6302`) (`#6305`) (Robert Levy)
* c2c6cec Docs: Mark object-shorthand as fixable. (`#6485`) (Nick Heiner)
* 5668236 Fix: Allow objectsInObjects exception when destructuring (fixes `#6469`) (`#6470`) (Adam Renklint)
* 17ac0ae Fix: `strict` rule reports a syntax error for ES2016 (fixes `#6405`) (`#6464`) (Toru Nagashima)
* 4545123 Docs: Rephrase documentation for `no-duplicate-imports` (`#6463`) (Simen Bekkhus)
* 1b133e3 Docs: improve `no-native-reassign` and specifying globals (fixes `#5358`) (`#6462`) (Toru Nagashima)
* b179373 Chore: Remove dead code in excuteOnFiles (fixes `#6467`) (`#6466`) (Andrew Hutchings)
* 18fbc4b Chore: Simplify eslint process exit code (fixes `#6368`) (`#6371`) (alberto)
* 58542e4 Breaking: Drop support for node < 4 (fixes `#4483`) (`#6401`) (alberto)
* f50657e Breaking: use default for complexity in eslint:recommended (fixes `#6021`) (`#6410`) (alberto)
* 3e690fb Fix: Exit init early if guide is chosen w/ no package.json (fixes `#6476`) (`#6478`) (Kai Cataldo)

#### Version 2.13.1
* 434de7f Fix: wrong baseDir (fixes `#6450`) (`#6457`) (Toru Nagashima)
* 3c9ce09 Fix: Keep indentation when fixing `padded-blocks` "never" (fixes `#6454`) (`#6456`) (Ed Lee)
* a9d4cb2 Docs: Fix typo in max-params examples (`#6471`) (J. William Ashton)
* 1e185b9 Fix: no-multiple-empty-lines errors when no line breaks (fixes `#6449`) (`#6451`) (strawbrary)

#### Version 2.13.0
* cf223dd Fix: add test for a syntax error (fixes `#6013`) (`#6378`) (Toru Nagashima)
* da30cf9 Update: Add fixer for object-shorthand (fixes `#6412`) (`#6418`) (Nick Heiner)
* 2cd90eb Chore: Fix rule meta description inconsistencies (refs `#5417`) (`#6422`) (Mark Pedrotti)
* d798b2c Added quotes around "classes" option key (`#6441`) (Guy Fraser)
* 852b6df Docs: Delete empty table of links from Code Path Analysis (`#6423`) (Mark Pedrotti)
* 5e9117e Chore: sort rules in eslint.json (fixes `#6425`) (`#6426`) (alberto)
* c2b5277 Docs: Add gitter chat link to Reporting Bugs (`#6430`) (Mark Pedrotti)
* 1316db0 Update: Add `never` option for `func-names` (fixes `#6059`) (`#6392`) (alberto)
* 1c123e2 Update: Add autofix for `padded-blocks` (fixes `#6320`) (`#6393`) (alberto)
* 8ec89c8 Fix: `--print-config` return config inside subdir (fixes `#6329`) (`#6385`) (alberto)
* 4f73240 Fix: `object-curly-newline` multiline with comments (fixes `#6381`) (`#6396`) (Toru Nagashima)
* 77697a7 Chore: Fake config hierarchy fixtures (fixes `#6206`) (`#6402`) (Gyandeep Singh)
* 73a9a6d Docs: Fix links in Configuring ESLint (`#6421`) (Mark Pedrotti)
* ed84c4c Fix: improve `newline-per-chained-call` message (fixes `#6340`) (`#6360`) (Toru Nagashima)
* 9ea4e44 Docs: Update parser reference to `espree` instead of `esprima` (`#6404`) (alberto)
* 7f57467 Docs: Make `fix` param clearer (fixes `#6366`) (`#6367`) (Nick Heiner)
* fb49c7f Fix: nested `extends` with relative path (fixes `#6358`) (`#6359`) (Toru Nagashima)
* 5122f73 Update: no-multiple-empty-lines fixer (fixes `#6225`) (`#6226`) (Ruurd Moelker)
* 0e7ce72 Docs: Fix rest-spread-spacing's name (`#6365`) (cody)
* cfdd524 Fix: allow semi as braceless body of statements (fixes `#6386`) (`#6391`) (alberto)
* 6b08cfc Docs: key-spacing fixable documenation notes (fixes `#6375`) (`#6376`) (Ruurd Moelker)
* 4b4be3b Docs: `max-lines` option: fix `skipComments` typo (`#6374`) (Jordan Harband)
* 20ab4f6 Docs: Fix wrong link in object-curly-newline (`#6373`) (Grant Snodgrass)
* 412ce8d Docs: Fix broken links in no-mixed-operators (`#6372`) (Grant Snodgrass)


#### Version 2.12.0
* 54c30fb Update: Add explicit default option `always` for `eqeqeq` (refs `#6144`) (`#6342`) (alberto)
* 2d63370 Update: max-len will warn indented comment lines (fixes `#6322`) (`#6324`) (Kai Cataldo)
* dcd4ad7 Docs: clarify usage of inline disable comments (fixes `#6335`) (`#6347`) (Kai Cataldo)
* c03300b Docs: Clarified how plugin rules look in plugin configs (fixes `#6346`) (`#6351`) (Kevin Partington)
* 9c87709 Docs: Add semantic versioning policy (fixes `#6244`) (`#6343`) (Nicholas C. Zakas)
* 5affab1 Docs: Describe values under Extending Configuration Files (refs `#6240`) (`#6336`) (Mark Pedrotti)
* 2520f5a New: `max-lines` rule (fixes `#6078`) (`#6321`) (alberto)
* 9bfbc64 Update: Option for object literals in `arrow-body-style` (fixes `#5936`) (`#6216`) (alberto)
* 977cdd5 Chore: remove unused method from FileFinder (fixes `#6344`) (`#6345`) (alberto)
* 477fbc1 Docs: Add section about customizing RuleTester (fixes `#6227`) (`#6331`) (Jeroen Engels)
* 0e14016 New: `no-mixed-operators` rule (fixes `#6023`) (`#6241`) (Toru Nagashima)
* 6e03c4b Update: Add never option to arrow-body-style (fixes `#6317`) (`#6318`) (Andrew Hyndman)
* f804397 New: Add `eslint:all` option (fixes `#6240`) (`#6248`) (Robert Fletcher)
* dfe05bf Docs: Link JSCS rules to their corresponding page. (`#6334`) (alberto)
* 1cc4356 Docs: Remove reference to numeric config (fixes `#6309`) (`#6327`) (Kevin Partington)
* 2d4efbe Docs: Describe options in rule under Strict Mode (`#6312`) (Mark Pedrotti)
* c1953fa Docs: Typo fix 'and' -> 'any' (`#6326`) (Stephen Edgar)
* d49ab4b Docs: Code conventions improvements (`#6313`) (Kevin Partington)
* 316a507 Fix: one-var allows uninitialized vars in ForIn/ForOf (fixes `#5744`) (`#6272`) (Kai Cataldo)
* 6cbee31 Docs: Typo fix 'colum' -> 'column' (`#6306`) (Andrew Cobby)
* 2663569 New: `object-curly-newline` (fixes `#6072`) (`#6223`) (Toru Nagashima)
* 72c2ea5 Update: callback-return allows for object methods (fixes `#4711`) (`#6277`) (Kai Cataldo)
* 89580a4 Docs: Distinguish examples in rules under Stylistic Issues part 5 (`#6291`) (Kenneth Williams)
* 1313804 New: rest-spread-spacing rule (fixes `#5391`) (`#6278`) (Kai Cataldo)
* 61dfe68 Fix: `no-useless-rename` false positive in babel-eslint (fixes `#6266`) (`#6290`) (alberto)
* c78c8cb Build: Remove commit check from appveyor (fixes `#6292`) (`#6294`) (alberto)
* 3e38fc1 Chore: more tests for comments at the end of blocks (refs `#6090`) (`#6273`) (Kai Cataldo)
* 38dccdd Docs: `--no-ignore` disables all forms of ignore (fixes `#6260`) (`#6304`) (alberto)
* bb69380 Fix: no-useless-rename handles ExperimentalRestProperty (fixes `#6284`) (`#6288`) (Kevin Partington)
* fca0679 Update: Improve perf not traversing default ignored dirs (fixes `#5679`) (`#6276`) (alberto)
* 320e8b0 Docs: Describe options in rules under Possible Errors part 4 (`#6270`) (Mark Pedrotti)
* 3e052c1 Docs: Mark no-useless-rename as fixable in rules index (`#6297`) (Dalton Santos)


