### PR TITLE
[Doppins] Upgrade dependency supertest to ^2.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "nodemailer-stub-transport": "^1.0.0",
     "sequelize-fixtures": "git+https://github.com/abakusbackup/sequelize-fixtures.git",
     "sinon": "^1.17.4",
-    "supertest": "^1.2.0"
+    "supertest": "^2.0.1"
   },
   "private": true
 }


### PR DESCRIPTION
Hi!

A new version was just released of `supertest`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded supertest from `^1.2.0` to `^2.0.1`

#### Changelog:

#### Version 2.0.0
PR-347 - Update to superagent ^2.0.0 (thanks `@saintedlama`)

