### PR TITLE
[Doppins] Upgrade dependency mocha to ^3.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "eslint-config-airbnb": "^9.0.0",
     "eslint-config-webkom": "^1.3.4",
     "eslint-plugin-import": "^1.6.1",
-    "mocha": "^2.4.5",
+    "mocha": "^3.1.2",
     "mongodb": "^2.1.16",
     "nodemailer-stub-transport": "^1.0.0",
     "sequelize-fixtures": "git+https://github.com/abakusbackup/sequelize-fixtures.git",


### PR DESCRIPTION
Hi!

A new version was just released of `mocha`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded mocha from `^2.4.5` to `^3.1.2`

#### Changelog:

#### Version 3.1.2
# 3.1.2 / 2016-10-10

## :bug: Bug Fix

- [`#2528`]: Recovery gracefully if an `Error`'s `stack` property isn't writable ([`@boneskull`])

[`#2528`]: `https://github.com/mochajs/mocha/issues/2528`


#### Version 3.1.1
# 3.1.1 / 2016-10-09

## :bug: Bug Fix

- [`#1417`]: Don't report `done()` was called multiple times when it wasn't ([`@frankleonrose`])
 
## :nut_and_bolt: Other

- [`#2490`]: Lint with [semistandard](https://npmjs.com/package/semistandard) config ([`@makepanic`])
- [`#2525`]: Lint all `.js` files ([`@boneskull`])
- [`#2524`]: Provide workaround for developers unable to run browser tests on macOS Sierra ([`@boneskull`])

[`#1417`]: `https://github.com/mochajs/mocha/issues/1417`
[`#2490`]: `https://github.com/mochajs/mocha/issues/2490`
[`#2525`]: `https://github.com/mochajs/mocha/issues/2525`
[`#2524`]: `https://github.com/mochajs/mocha/issues/2524`
[`@makepanic`]: https://github.com/makepanic
[`@frankleonrose`]: https://github.com/frankleonrose


#### Version 3.1.0
# 3.1.0 / 2016-09-27

## :tada: Enhancement

- [`#2357`]: Support `--inspect` on command-line ([`@simov`])
- [`#2194`]: Human-friendly error if no files are matched on command-line ([`@Munter`])
- [`#1744`]: Human-friendly error if a Suite has no callback (BDD/TDD only) ([`@anton`])

## :bug: Bug Fix

- [`#2488`]: Fix case in which *variables beginning with lowercase "D"* may not have been reported properly as global leaks ([`@JustATrick`]) :laughing:
- [`#2465`]: Always halt execution in async function when `this.skip()` is called ([`@boneskull`])
- [`#2445`]: Exits with expected code 130 when `SIGINT` encountered; exit code can no longer rollover at 256 ([`@Munter`])
- [`#2315`]: Fix uncaught TypeError thrown from callback stack ([`@1999`])
- Fix broken `only()`/`skip()` in IE7/IE8 ([`@boneskull`])
- [`#2502`]: Fix broken stack trace filter on Node.js under Windows ([`@boneskull`]) 
- [`#2496`]: Fix diff output for objects instantiated with `String` constructor ([more](https://youtrack.jetbrains.com/issue/WEB-23383)) ([`@boneskull`])

[`#2496`]: `https://github.com/mochajs/mocha/issues/2496`
[`#2502`]: `https://github.com/mochajs/mocha/issues/2502`
[`#2315`]: `https://github.com/mochajs/mocha/issues/2315`
[`#2445`]: `https://github.com/mochajs/mocha/pull/2445`
[`#2465`]: `https://github.com/mochajs/mocha/issues/2465`
[`#2488`]: `https://github.com/mochajs/mocha/issues/2488`
[`#1744`]: `https://github.com/mochajs/mocha/issues/1744`
[`#2194`]: `https://github.com/mochajs/mocha/issues/2194`
[`#2357`]: `https://github.com/mochajs/mocha/issues/2357`
[`@1999`]: https://github.com/1999
[`@JustATrick`]: https://github.com/JustATrick
[`@anton`]: https://github.com/anton
[`@simov`]: https://github.com/simov
[`@Munter`]: https://github.com/munter
[`@boneskull`]: https://github.com/boneskull

#### Version 3.0.2


#### Version 3.0.0
See `#2350` and `CHANGELOG.md` in the `v3.0.0` branch.

#### Version 3.0.0
See `#2350` for more information.

#### Version 3.0.0
See `#2350` for more information.

