### PR TITLE
[Doppins] Upgrade dependency eslint to 3.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "chai": "^3.5.0",
     "chai-as-promised": "^6.0.0",
     "commander": "^2.9.0",
-    "eslint": "3.9.1",
+    "eslint": "3.10.0",
     "eslint-config-airbnb": "^9.0.0",
     "eslint-config-webkom": "^1.3.4",
     "eslint-plugin-import": "^2.2.0",


### PR DESCRIPTION
Hi!

A new version was just released of `eslint`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded eslint from `3.9.1` to `3.10.0`

