### PR TITLE
[Doppins] Upgrade dependency eslint to 3.10.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "chai": "^3.5.0",
     "chai-as-promised": "^6.0.0",
     "commander": "^2.9.0",
-    "eslint": "3.9.1",
+    "eslint": "3.10.1",
     "eslint-config-airbnb": "^9.0.0",
     "eslint-config-webkom": "^1.3.4",
     "eslint-plugin-import": "^2.2.0",


### PR DESCRIPTION
Hi!

A new version was just released of `eslint`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded eslint from `3.9.1` to `3.10.1`

#### Changelog:

#### Version 3.10.1
* 8a0e92a Fix: handle try/catch correctly in `no-return-await` (fixes `#7581`) (`#7582`) (Teddy Katz)
* c4dd015 Fix: no-useless-return stack overflow on unreachable loops (fixes `#7583`) (`#7584`) (Teddy Katz)

#### Version 3.10.0
* 7ee039b Update: Add comma-style options for calls, fns, imports (fixes `#7470`) (Max Englander)
* 670e060 Chore: make the `object-shorthand` tests more readable (`#7580`) (Teddy Katz)
* c3f4809 Update: Allow `func-names` to recognize inferred ES6 names (fixes `#7235`) (`#7244`) (Logan Smyth)
* b8d6e48 Fix: syntax errors created by `object-shorthand` autofix (fixes `#7574`) (`#7575`) (Teddy Katz)
* 1b3b65c Chore: ensure that files in tests/conf are linted (`#7579`) (Teddy Katz)
* 2bd1dd7 Update: avoid creating extra whitespace in `arrow-body-style` fixer (`#7504`) (Teddy Katz)
* 66fe9ff New: `no-return-await` rule. (fixes `#7537`) (`#7547`) (Jordan Harband)
* 759525e Chore: Use process.exitCode instead of process.exit() in bin/eslint.js (`#7569`) (Teddy Katz)
* 0d60db7 Fix: Curly rule doesn't account for leading comment (fixes `#7538`) (`#7539`) (Will Chen)
* 5003b1c Update: fix in/instanceof handling with `space-infix-ops` (fixes `#7525`) (`#7552`) (Teddy Katz)
* 3e6131e Docs: explain config option merging (`#7499`) (Danny Andrews)
* 1766524 Update: "Error type should be" assertion in rule-tester (fixes 6106) (`#7550`) (Frans Jaspers)
* 44eb274 Docs: Missing semicolon report was missing a comma (`#7553`) (James)
* 6dbda15 Docs: Document the optional defaults argument for RuleTester (`#7548`) (Teddy Katz)
* e117b80 Docs: typo fix (`#7546`) (oprogramador)
* 25e5613 Chore: Remove incorrect test from indent.js. (`#7531`) (Scott Stern)
* c0f4937 Fix: `arrow-parens` supports type annotations (fixes `#7406`) (`#7436`) (Toru Nagashima)
* a838b8e Docs: `func-name-matching`: update with “always”/“never” option (`#7536`) (Jordan Harband)
* 3c379ff Update: `no-restricted-{imports,modules}`: add “patterns” (fixes `#6963`) (`#7433`) (Jordan Harband)
* f5764ee Docs: Update example of results returned from `executeOnFiles` (`#7362`) (Simen Bekkhus)
* 4613ba0 Fix: Add support for escape char in JSX. (`#7461`) (Scott Stern)
* ea0970d Fix: `curly` false positive with no-semicolon style (`#7509`) (Teddy Katz)
* af1fde1 Update: fix `brace-style` false negative on multiline node (fixes `#7493`) (`#7496`) (Teddy Katz)
* 3798aea Update: max-statements to report function name (refs `#7260`) (`#7399`) (Nicholas C. Zakas)
* 0c215fa Update: Add `ArrowFunctionExpression` support to `require-jsdoc` rule (`#7518`) (Gyandeep Singh)
* 578c373 Build: handle deprecated rules with no 'replacedBy' (refs `#7471`) (`#7494`) (Vitor Balocco)
* a7f3976 Docs: Specify min ESLint version for new rule format (`#7501`) (cowchimp)
* 8a3e717 Update: Fix `lines-around-directive` semicolon handling (fixes `#7450`) (`#7483`) (Teddy Katz)
* e58cead Update: add a fixer for certain statically-verifiable `eqeqeq` cases (`#7389`) (Teddy Katz)
* 0dea0ac Chore: Add Node 7 to travis ci build (`#7506`) (Gyandeep Singh)
* 36338f0 Update: add fixer for `no-extra-boolean-cast` (`#7387`) (Teddy Katz)
* 183def6 Chore: enable `prefer-arrow-callback` on ESLint codebase (fixes `#6407`) (`#7503`) (Teddy Katz)
* 4f1fa67 Docs: Update copyright (`#7497`) (Nicholas C. Zakas)

