### PR TITLE
[Doppins] Upgrade dependency errorhandler to 1.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "continuation-local-storage": "3.2.0",
     "cookie-parser": "1.4.3",
     "cors": "2.8.1",
-    "errorhandler": "1.4.3",
+    "errorhandler": "1.5.0",
     "express": "4.13.4",
     "express-handlebars": "^3.0.0",
     "express-jwt": "5.1.0",


### PR DESCRIPTION
Hi!

A new version was just released of `errorhandler`, so [Doppins](https://doppins.com)
has upgraded your project's dependency ranges.

Make sure that it doesn't break anything, and happy merging! :shipit:

---
### Upgraded errorhandler from `1.4.3` to `1.5.0`

#### Changelog:

#### Version 1.5.0
  * Pretty print JSON error response
  * deps: accepts@~1.3.3
    - deps: mime-types@~2.1.11
    - deps: negotiator@0.6.1
  * perf: front-load HTML template and stylesheet at middleware construction
  * perf: only load template and stylesheet once
  * perf: resolve file paths at start up

